### PR TITLE
Added 'selected' as a prop to allow setting selected state externally

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -108,6 +108,7 @@ class BootstrapTable extends React.Component{
             keyField={this.store.getKeyField()}
             condensed={this.props.condensed}
             selectRow={this.props.selectRow}
+            selected={this.props.selected}
             cellEdit={this.props.cellEdit}/>
           {tableFilter}
         </div>
@@ -315,7 +316,8 @@ BootstrapTable.propTypes = {
   insertRow: React.PropTypes.bool,
   deleteRow: React.PropTypes.bool,
   search: React.PropTypes.bool,
-  columnFilter: React.PropTypes.bool
+  columnFilter: React.PropTypes.bool,
+  selected: React.PropTypes.array
 };
 BootstrapTable.defaultProps = {
   height: "100%",

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -11,7 +11,7 @@ class TableBody extends React.Component{
 		super(props);
     this.state = {
       currEditCell: null,
-      selectedRowKey: []
+      selectedRowKey: props.selected || []
     };
     this._attachRowSelectFunc();
     this.editing = false;
@@ -209,6 +209,7 @@ TableBody.propTypes = {
   striped: React.PropTypes.bool,
   hover: React.PropTypes.bool,
   condensed: React.PropTypes.bool,
-  keyField: React.PropTypes.string
+  keyField: React.PropTypes.string,
+  selected: React.PropTypes.array
 };
 export default TableBody;

--- a/src/TableFilter.js
+++ b/src/TableFilter.js
@@ -5,6 +5,7 @@ import classSet from 'classnames';
 class TableFilter extends React.Component{
 
   constructor(props) {
+    super(props);
     this.filterObj = {};
   }
 

--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -14,6 +14,7 @@ function _sort(arr, sortField, order){
 
 export class TableDataSet extends EventEmitter{
   constructor(data){
+    super(data);
     this.data = data;
   }
 


### PR DESCRIPTION
Needed to be able to save checked item list further up so that it could be passed in again if the component was unmounted and then remounted (via react-router in this case). Simple changes just to allow 'selected' array as a prop.

The super call changes were just due to babel yelling at me that you cannot access 'this' before a super call. You can safely ignore them if this was just oddities in my transpiling process.

Also, on an unrelated note, setting props to true with prop={true} is unnecessary. It can certainly be clearer, but I think this looks a bit cleaner:

```js
<BootstrapTable data={products} striped hover pagination search>...
```
Anyhow, thanks for the great work on this.