### PR TITLE
Show a message when the table is empty

### DIFF
--- a/dist/react-bootstrap-table.min.js
+++ b/dist/react-bootstrap-table.min.js
@@ -20847,6 +20847,19 @@ var TableBody = (function (_React$Component) {
             tableColumns
           );
         }, this);
+
+        if (tableRows.length === 0) {
+          tableRows.push(React.createElement(
+            TableRow,
+            { key: "##table-empty##" },
+            React.createElement(
+              "td",
+              { colSpan: this.props.columns.length, style: { textAlign: "center" } },
+              "There is no data to display"
+            )
+          ));
+        }
+
         this.editing = false;
         return React.createElement(
           "div",

--- a/lib/TableBody.js
+++ b/lib/TableBody.js
@@ -153,6 +153,19 @@ var TableBody = (function (_React$Component) {
             tableColumns
           );
         }, this);
+
+        if (tableRows.length === 0) {
+          tableRows.push(React.createElement(
+            TableRow,
+            { key: "##table-empty##" },
+            React.createElement(
+              "td",
+              { colSpan: this.props.columns.length, style: { textAlign: "center" } },
+              "There is no data to display"
+            )
+          ));
+        }
+
         this.editing = false;
         return React.createElement(
           "div",

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -128,6 +128,13 @@ class TableBody extends React.Component{
         </TableRow>
       )
     }, this);
+
+    if(tableRows.length === 0){
+      tableRows.push(<TableRow key="##table-empty##">
+        <td colSpan={this.props.columns.length} style={{ textAlign: "center" }}>There is no data to display</td>
+      </TableRow>)
+    }
+
     this.editing = false;
     return(
       <div className={containerClasses}>


### PR DESCRIPTION
Currently, when tables have no data, or a search returns no data the table looks a little odd and empty. This PR adds the below behaviour instead of rendering the table with no rows.

![screenshot from 2015-08-15 10-38-27](https://cloud.githubusercontent.com/assets/1327476/9288344/cbbf814e-4339-11e5-8dd4-8f3db269b0c7.png)
