### PR TITLE
Fix "window is undefined" bug on node.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var TableHeaderColumn = _interopRequire(require("./TableHeaderColumn"));
 
 var TableDataSet = require("./store/TableDataStore").TableDataSet;
 
-if (window) {
+if (typeof window !== 'undefined') {
   window.BootstrapTable = BootstrapTable;
   window.TableHeaderColumn = TableHeaderColumn;
 }


### PR DESCRIPTION
Node.Js will throw an error if you check for "window" directly. This is a workaround for that problem.