### PR TITLE
Ensuring pagination is maintained when using TableDataSet as the data model instead of a simple array

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -37,7 +37,7 @@ class BootstrapTable extends React.Component{
 	  this.props.oldDataLength = _data.length;
 	  this.props.data.clear();
       this.props.data.on('change', (data) => {
-		  //TODO: Allen to Review. Is this the right way of doing things? Or modify set state method to take in add/edit/delete additional param to know what has changed in the data?
+		//TODO: Allen to Review. Is this the right way of doing things? Or modify set state method to take in add/edit/delete additional param to know what has changed in the data?
 		var dataAdded = false;
 		var dataRemoved = false;	
 		if(_this.props.oldDataLength < data.length) //add 

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -32,13 +32,73 @@ class BootstrapTable extends React.Component{
       throw "Error. No any key column defined in TableHeaderColumn. Use 'isKey={true}' to specify an unique column after version 0.5.4.";
 
     if(!Array.isArray(this.props.data)){
-      this.store = new TableDataStore(this.props.data.getData());
-      this.props.data.clear();
+      var _data = this.props.data.getData();
+      this.store = new TableDataStore(_data);	  
+	  this.props.oldDataLength = _data.length;
+	  this.props.data.clear();
       this.props.data.on('change', (data) => {
-        this.store.setData(data);
-        this.setState({
-          data: this.getTableData()
-        })
+		  //TODO: Allen to Review. Is this the right way of doing things? Or modify set state method to take in add/edit/delete additional param to know what has changed in the data?
+		var dataAdded = false;
+		var dataRemoved = false;	
+		if(_this.props.oldDataLength < data.length) //add 
+		{
+			dataAdded = true;
+			_this.props.oldDataLength = data.length;
+		}
+		else if(_this.props.oldDataLength > data.length) //delete 
+		{
+			dataRemoved = true;
+			_this.props.oldDataLength = data.length;
+		}
+		
+		_this.store.setData(data);		
+		var result = undefined;
+		if(dataAdded)
+		{
+			  if (_this.props.pagination) {
+			  //if pagination is enabled and insert row be trigger, change to last page
+			  var sizePerPage = _this.refs.pagination.getSizePerPage();
+			  var currLastPage = Math.ceil(_this.store.getDataNum() / sizePerPage);
+			  result = _this.store.page(currLastPage, sizePerPage).get();
+			  _this.setState({
+				data: result
+			  });
+			  _this.refs.pagination.changePage(currLastPage);
+			} else {
+			  result = _this.store.get();
+			  _this.setState({
+				data: result
+			  });
+			}	
+		}
+		else if(dataRemoved)
+		{
+		 if (this.props.pagination) {
+          var sizePerPage = this.refs.pagination.getSizePerPage();
+          var currLastPage = Math.ceil(this.store.getDataNum() / sizePerPage);
+          var currentPage = this.refs.pagination.getCurrentPage();
+          if (currentPage > currLastPage) currentPage = currLastPage;
+          result = this.store.page(currentPage, sizePerPage).get();
+          this.setState({
+            data: result
+          });
+          this.refs.pagination.changePage(currentPage);
+        } else {
+          result = this.store.get();
+          this.setState({
+            data: result
+          });
+        }
+		}
+		else
+		{
+		   var sizePerPage = this.refs.pagination.getSizePerPage();
+		   var currentPage = this.refs.pagination.getCurrentPage();
+		   result = this.store.page(currentPage, sizePerPage).get();
+		  _this.setState({
+           data: result
+			});
+		}
       }.bind(this));
     } else{
       this.store = new TableDataStore(this.props.data);


### PR DESCRIPTION
There was an issue wherein when using TableDataSet as the model, calling setState on add/edit/delete on the model was not paginating correctly(as compared to Add/Delete/Edit row show in the demo - which uses a simple array as the model)

Am more inclined to think to have an enum passed to setState method to know what exactly is the state change - add/edit/delete and handle pagination accordingly than to rely on the using the old data length as I have used. 

@AllenFang , my machine's python and node is failing, so could not run gulp to regenerate the bundle nor run the tests. Can you please run that before merging the pull request? 