### PR TITLE
Chore: csv back to comma delimited

### DIFF
--- a/src/csv_export_util.js
+++ b/src/csv_export_util.js
@@ -5,12 +5,12 @@ function toString(data, keys) {
   var dataString = "";
   if (data.length === 0) return dataString;
   
-  dataString += keys.join('\t') + '\n'
+  dataString += keys.join(',') + '\n'
 
   data.map(function(row) {
     keys.map(function(col) {
-      var cell = row[col] ? row[col] : "";
-      dataString += row[col] + '\t';
+      var cell = row[col] ? ('"'+row[col]+'"') : "";
+      dataString += cell + ',';
     });
 
     dataString += '\n';


### PR DESCRIPTION
@AllenFang excel default open is by comma delimited so it's annoying to open manually with tab delimited.

So I changed it back to comma delimiter with "" wrapped around to escape the commas in cell.