### PR TITLE
TableDataSet is now available via Window object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {TableDataSet} from './store/TableDataStore';
 if(typeof window !== 'undefined'){
   window.BootstrapTable = BootstrapTable;
   window.TableHeaderColumn = TableHeaderColumn;
+  window.TableDataSet = TableDataSet;
 }
 export default {
   BootstrapTable,


### PR DESCRIPTION
Example use
var ReactBsTable = window.BootstrapTable;
var ReactTds = window.TableDataSet; //import TableDataSet
var dataSet = new ReactTds(products);