### PR TITLE
Fix rare bug where pagination lost

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -78,22 +78,14 @@ class BootstrapTable extends React.Component {
   getTableData(props) {
     let result = [];
     if (props.pagination) {
-      let page = props.options.page;
-      let sizePerPage = props.options.sizePerPage;
-      if(!page){
-        if(!this.refs.pagination){
-          page = 1;
-        } else {
-          page = this.refs.pagination.getCurrentPage();
-        }
+      let page = props.options.page || 1;
+      let sizePerPage = props.options.sizePerPage || Const.SIZE_PER_PAGE;
+
+      if(this.refs.pagination) {
+        sizePerPage = this.refs.pagination.getSizePerPage();
+        page = this.refs.pagination.getCurrentPage();
       }
-      if(!sizePerPage){
-        if(!this.refs.pagination){
-          sizePerPage = Const.SIZE_PER_PAGE;
-        } else {
-          sizePerPage = this.refs.pagination.getSizePerPage();
-        }
-      }
+
       // #125
       if(page >= props.data.length / sizePerPage) page = 1;
       result = this.store.page(page, sizePerPage).get();


### PR DESCRIPTION
After updating I found out I still had problems with pagination size and page getting lost. You can recreate the problem in the updated gist: https://gist.github.com/frontsideair/2ec7c1356b4001366ef9

I think the code is a little bit simplified while covering all the cases previously covered. I just made it so the priority of pagination selector is higher than props. If you see any case missing just let me know. I tested it by hand so it may be a good idea to test it yourself.