### PR TITLE
Search bar too small on small screens (eg. iphone4/5)

### DIFF
--- a/src/toolbar/ToolBar.js
+++ b/src/toolbar/ToolBar.js
@@ -134,8 +134,8 @@ class ToolBar extends React.Component{
 
     return(
       <div className="row">
-        <div className="col-xs-9">
-          <div className="col-xs-12 col-sm-6 col-md-6 col-lg-8" role="group">
+        <div className="col-xs-12 col-sm-6 col-md-6 col-lg-8">
+          <div className="btn-group btn-group-sm" role="group">
             {exportCSV}
             {insertBtn}
             {deleteBtn}

--- a/src/toolbar/ToolBar.js
+++ b/src/toolbar/ToolBar.js
@@ -135,13 +135,13 @@ class ToolBar extends React.Component{
     return(
       <div className="row">
         <div className="col-xs-9">
-          <div className="btn-group btn-group-sm" role="group">
+          <div className="col-xs-12 col-sm-6 col-md-6 col-lg-8" role="group">
             {exportCSV}
             {insertBtn}
             {deleteBtn}
           </div>
         </div>
-        <div className="col-xs-3">
+        <div className="col-xs-12 col-sm-6 col-md-6 col-lg-4">
           {searchTextInput}
         </div>
         <Notifier ref="notifier"></Notifier>


### PR DESCRIPTION
On an iPhone sized screen, the search box becomes one and a half characters wide. It also overlaps on top of some buttons if they are enabled.
This further doesn't make sense if none of the three buttons in the first column (exportCSV, deleteBtn, insertBtn) are even enabled.

My change ensures the search field sits below the buttons and at a decent width for small screens.

The change which prompted this issue was [this one](https://github.com/AllenFang/react-bootstrap-table/commit/8e43d26d03cb378bfd7f70e57b495248c134730e#diff-c2216bf93dd49b5ad9bf3f7422d40ffcR144).

By the way, I'm loving this library, it's fantastic! Awesome job everyone!