### PR TITLE
Fix: The table should be sortable when a column is hidden programmatically

### DIFF
--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -110,6 +110,8 @@ export class TableDataStore {
     };
 
     let currentDisplayData = this.getCurrentDisplayData();
+    if(!this.colInfos[sortField]) return this;
+
     const { sortFunc } = this.colInfos[sortField];
     currentDisplayData = _sort(currentDisplayData, sortField, order, sortFunc);
 


### PR DESCRIPTION
### Issue: 
When the table column are hidden/rendered programmatically(depending on state), the `this.colInfos[sortField]` returns undefined.

### Solution
Check if the column exist before the column is sorted.