### PR TITLE
Fix pagination lost bug

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -119,10 +119,8 @@ class BootstrapTable extends React.Component {
     if (Array.isArray(nextProps.data)) {
       this.store.setData(nextProps.data);
       let paginationDom = this.refs.pagination;
-      let page = nextProps.options.page ||
-                  (paginationDom ? paginationDom.getCurrentPage() : 1);
-      let sizePerPage = nextProps.options.sizePerPage ||
-                  (paginationDom ? paginationDom.getSizePerPage() : Const.SIZE_PER_PAGE_LIST[0]);
+      let page = paginationDom && paginationDom.getCurrentPage() || nextProps.options.page || 1;
+      let sizePerPage = paginationDom && paginationDom.getSizePerPage() || nextProps.options.sizePerPage || Const.SIZE_PER_PAGE_LIST[0];
       // #125
       if(page > Math.ceil(nextProps.data.length / sizePerPage)) page = 1;
       let sortInfo = this.store.getSortInfo();


### PR DESCRIPTION
I've changed the order of preference for page and pagination size when receiving props. It would prefer nextProps over current page, which caused problems for me. It might work when you handle the selection inside the component, but as I'm giving this as a prop, it's triggered at times when it wasn't expected.

With this PR it'll prefer current page and pagination size over the ones provided by props.