### PR TITLE
Fix null check bug

### DIFF
--- a/src/TableColumn.js
+++ b/src/TableColumn.js
@@ -20,7 +20,7 @@ class TableColumn extends React.Component{
       return shouldUpdated;
     }
 
-    if(typeof children === 'object') {
+    if(typeof children === 'object' && children !== null) {
       if(children.props.type === 'checkbox' || children.props.type === 'radio') {
         shouldUpdated = shouldUpdated ||
           children.props.type !== nextProps.children.props.type ||


### PR DESCRIPTION
This PR is related to #260 

When we update state, TableColumn's shouldComponentUpdate throws an error, so the table is not updated correctly.

```js
if(typeof children === 'object') {
   if(children.props.type === 'checkbox' || children.props.type === 'radio') {
```

`typeof` operator returns 'object' when it receives null value, so when we try to access to the props of `children`, a ReferenceError is thrown.