### PR TITLE
Pagination formatting fix

### DIFF
--- a/src/pagination/PaginationList.js
+++ b/src/pagination/PaginationList.js
@@ -59,26 +59,28 @@ class PaginationList extends React.Component {
       <div className="row" style={{ marginTop: 15 }}>
         {
           this.props.sizePerPageList.length > 1
-          ? <div className="col-md-6">
-              <div className="dropdown">
-                <button className="btn btn-default dropdown-toggle" type="button" id="pageDropDown" data-toggle="dropdown"
-                        aria-expanded="true">
-                  {this.props.sizePerPage}
-                  <span>
-                    {" "}
-                    <span className="caret"/>
-                  </span>
-                </button>
-                <ul className="dropdown-menu" role="menu" aria-labelledby="pageDropDown">
-                  {sizePerPageList}
-                </ul>
-              </div>
+          ? <div>
               <div className="col-md-6">
-                <ul className="pagination" style={pageListStyle}>
-                  {pageBtns}
-                </ul>
+                  <div className="dropdown">
+                    <button className="btn btn-default dropdown-toggle" type="button" id="pageDropDown" data-toggle="dropdown"
+                            aria-expanded="true">
+                      {this.props.sizePerPage}
+                      <span>
+                        {" "}
+                        <span className="caret"/>
+                      </span>
+                    </button>
+                    <ul className="dropdown-menu" role="menu" aria-labelledby="pageDropDown">
+                      {sizePerPageList}
+                    </ul>
+                  </div>
+                </div>
+                <div className="col-md-6">
+                  <ul className="pagination" style={pageListStyle}>
+                    {pageBtns}
+                  </ul>
+                </div>
               </div>
-            </div>
           : <div className="col-md-12">
               <ul className="pagination" style={pageListStyle}>
                 {pageBtns}

--- a/src/pagination/PaginationList.js
+++ b/src/pagination/PaginationList.js
@@ -57,30 +57,34 @@ class PaginationList extends React.Component {
 
     return (
       <div className="row" style={{ marginTop: 15 }}>
-        <div className="col-md-6">
         {
-          this.props.sizePerPageList.length > 1 ?
-          <div className="dropdown">
-            <button className="btn btn-default dropdown-toggle" type="button" id="pageDropDown" data-toggle="dropdown"
-                    aria-expanded="true">
-              {this.props.sizePerPage}
-              <span>
-                {" "}
-                <span className="caret"/>
-              </span>
-            </button>
-            <ul className="dropdown-menu" role="menu" aria-labelledby="pageDropDown">
-              {sizePerPageList}
-            </ul>
-          </div>
-          : ""
+          this.props.sizePerPageList.length > 1
+          ? <div className="col-md-6">
+              <div className="dropdown">
+                <button className="btn btn-default dropdown-toggle" type="button" id="pageDropDown" data-toggle="dropdown"
+                        aria-expanded="true">
+                  {this.props.sizePerPage}
+                  <span>
+                    {" "}
+                    <span className="caret"/>
+                  </span>
+                </button>
+                <ul className="dropdown-menu" role="menu" aria-labelledby="pageDropDown">
+                  {sizePerPageList}
+                </ul>
+              </div>
+              <div className="col-md-6">
+                <ul className="pagination" style={pageListStyle}>
+                  {pageBtns}
+                </ul>
+              </div>
+            </div>
+          : <div className="col-md-12">
+              <ul className="pagination" style={pageListStyle}>
+                {pageBtns}
+              </ul>
+            </div>
         }
-        </div>
-        <div className="col-md-6">
-          <ul className="pagination" style={pageListStyle}>
-            {pageBtns}
-          </ul>
-        </div>
       </div>
     )
   }


### PR DESCRIPTION
… provided.

When no sizePerPageList prop is supplied, or if there's only one element, the class on the pageList is now properly set to reduce instances of button overflow.