### PR TITLE
Set the column text as the title of the column header

### DIFF
--- a/src/TableHeaderColumn.js
+++ b/src/TableHeaderColumn.js
@@ -74,7 +74,7 @@ class TableHeaderColumn extends React.Component{
     var classes = this.props.className+" "+(this.props.dataSort?"sort-column":"");
     return(
       <th ref='header-col' className={classes} style={thStyle}>
-        <div ref="innerDiv" className="th-inner table-header-column"
+        <div ref="innerDiv" className="th-inner table-header-column" title={this.props.children}
           onClick={this.handleColumnClick.bind(this)}>
           {this.props.children}{sortCaret}
         </div>


### PR DESCRIPTION
With small columns, it's not sure the full header text can fit.
To account for this case, set the title attribute of the column header to the text of the column header.
That way, if the text is not completely visible, hovering the mouse on the header will display the text.

This makes the assumption that this.props.children is a string, but that seems to be already the case for the filters seem to expect that.

Otherwise, it might be convenient to allow manually setting the title attribute as a property of TableHeaderColumn