### PR TITLE
improve the example about selection externally last page event issue

### DIFF
--- a/examples/js/selection/externally-managed-selection.js
+++ b/examples/js/selection/externally-managed-selection.js
@@ -23,14 +23,21 @@ export default class ExternallyManagedSelection extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selected: []
+      selected: [],
+      currPage: 1
     };
   }
 
   render() {
-    const onRowSelect = ({ id }, isSelected) => {
+    const {
+      currPage
+    } = this.state;
+    const onRowSelect = ({ id }, isSelected, page) => {
       if (isSelected && this.state.selected.length !== 2) {
-        this.setState({ selected: [ ...this.state.selected, id ].sort() });
+        this.setState({
+          selected: [ ...this.state.selected, id ].sort(),
+          currPage: page
+        });
       } else {
         this.setState({ selected: this.state.selected.filter(it => it !== id) });
       }
@@ -47,6 +54,7 @@ export default class ExternallyManagedSelection extends React.Component {
     const options = {
       sizePerPageList: [ 5, 10, 15, 20 ],
       sizePerPage: 10,
+      page: currPage,
       sortName: 'id',
       sortOrder: 'desc'
     };

--- a/examples/js/selection/externally-managed-selection.js
+++ b/examples/js/selection/externally-managed-selection.js
@@ -32,11 +32,11 @@ export default class ExternallyManagedSelection extends React.Component {
     const {
       currPage
     } = this.state;
-    const onRowSelect = ({ id }, isSelected, page) => {
+    const onRowSelect = ({ id }, isSelected) => {
       if (isSelected && this.state.selected.length !== 2) {
         this.setState({
           selected: [ ...this.state.selected, id ].sort(),
-          currPage: page
+          currPage: this.refs.table.state.currPage
         });
       } else {
         this.setState({ selected: this.state.selected.filter(it => it !== id) });
@@ -60,7 +60,7 @@ export default class ExternallyManagedSelection extends React.Component {
     };
 
     return (
-      <BootstrapTable data={ products } selectRow={ selectRowProp } pagination={ true } options={ options }>
+      <BootstrapTable ref='table' data={ products } selectRow={ selectRowProp } pagination={ true } options={ options }>
         <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>
         <TableHeaderColumn dataField='name'>Product Name</TableHeaderColumn>
         <TableHeaderColumn dataField='price'>Product Price</TableHeaderColumn>

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -389,15 +389,12 @@ class BootstrapTable extends Component {
   }
 
   handleSelectRow = (row, isSelected) => {
-    const {
-      currPage
-    } = this.state;
     let result = true;
     let currSelected = this.store.getSelectedRowKeys();
     const rowKey = row[ this.store.getKeyField() ];
     const { selectRow } = this.props;
     if (selectRow.onSelect) {
-      result = selectRow.onSelect(row, isSelected, currPage);
+      result = selectRow.onSelect(row, isSelected);
     }
 
     if (typeof result === 'undefined' || result !== false) {

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -389,12 +389,15 @@ class BootstrapTable extends Component {
   }
 
   handleSelectRow = (row, isSelected) => {
+    const {
+      currPage
+    } = this.state;
     let result = true;
     let currSelected = this.store.getSelectedRowKeys();
     const rowKey = row[ this.store.getKeyField() ];
     const { selectRow } = this.props;
     if (selectRow.onSelect) {
-      result = selectRow.onSelect(row, isSelected);
+      result = selectRow.onSelect(row, isSelected, currPage);
     }
 
     if (typeof result === 'undefined' || result !== false) {


### PR DESCRIPTION
improve the example about selection externally-managed-selection last page event issue, because the last page always back to the first page.

1. added the currPage state for externally-managed-selection to avoid if the state was changed, and get the correct page.

2. added the handleSelectRow result call back, currPage parameter.

I think changed this issue maybe improve the user experience.