### PR TITLE
Don't change sort on props update

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -146,8 +146,8 @@ class BootstrapTable extends Component {
       page = 1;
     }
     const sortInfo = this.store.getSortInfo();
-    const sortField = options.sortName || (sortInfo ? sortInfo.sortField : undefined);
-    const sortOrder = options.sortOrder || (sortInfo ? sortInfo.order : undefined);
+    const sortField = sortInfo ? sortInfo.sortField : options.sortName;
+    const sortOrder = sortInfo ? sortInfo.order : options.sortOrder;
     if (sortField && sortOrder) this.store.sort(sortOrder, sortField);
     const data = this.store.page(page, sizePerPage).get();
     this.setState({


### PR DESCRIPTION
We have a react-redux application where component above the table re-renders after click on a table row. The table receives same props, but sort is reset to default. I belive it is either a bug or bad name for `sortName` and `sortOrder` options - the default shouldn't be prefered over user choice.

Documentation says:
sortName : String : Assign a default sort field.
sortOrder : String(asc/desc) : Assign a default sort ordering.