### PR TITLE
Fixed validator type

### DIFF
--- a/examples/js/advance/demo.js
+++ b/examples/js/advance/demo.js
@@ -4,6 +4,7 @@ import EditTypeTable from './edit-type-table';
 import DataInsertTypeTable from './insert-type-table';
 import AutoRowKeyTable from './auto-rowkey-table';
 import ValidatorTable from './validator-table';
+import ValidatorRowNotifierTable from './validator-row-notifier-table';
 
 import renderLinks from '../utils';
 
@@ -28,6 +29,10 @@ class Demo extends React.Component {
         <Panel header={ 'Data Validator Example(Job Name length must great 10 char)' }>
           { renderLinks('advance/validator-table.js') }
           <ValidatorTable/>
+        </Panel>
+        <Panel header={ 'Data Validator Example(Job Name length must great 10 char) and row can use the notifier.' }>
+          { renderLinks('advance/validator-table.js') }
+          <ValidatorRowNotifierTable/>
         </Panel>
       </Col>
     );

--- a/examples/js/advance/demo.js
+++ b/examples/js/advance/demo.js
@@ -31,7 +31,7 @@ class Demo extends React.Component {
           <ValidatorTable/>
         </Panel>
         <Panel header={ 'Data Validator Example(Job Name length must great 10 char) and row can use the notifier.' }>
-          { renderLinks('advance/validator-table.js') }
+          { renderLinks('advance/validator-row-notifier-table.js') }
           <ValidatorRowNotifierTable/>
         </Panel>
       </Col>

--- a/examples/js/advance/validator-row-notifier-table.js
+++ b/examples/js/advance/validator-row-notifier-table.js
@@ -1,0 +1,56 @@
+/* eslint max-len: 0 */
+import React from 'react';
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
+
+
+const jobs = [];
+const jobTypes = [ 'A', 'B', 'C', 'D' ];
+
+function addJobs(quantity) {
+  const startId = jobs.length;
+  for (let i = 0; i < quantity; i++) {
+    const id = startId + i;
+    jobs.push({
+      id: id,
+      name: 'Item name ' + id,
+      type: 'B',
+      active: i % 2 === 0 ? 'Y' : 'N'
+    });
+  }
+}
+
+addJobs(5);
+
+const cellEditProp = {
+  mode: 'click',
+  blurToSave: true
+};
+
+// if you would like to appear the notifier to row, must be add the object and set the validation state within.
+function jobNameValidator(value) {
+  if (!value) {
+    return {
+      validate: false,
+      tip: 'Job Name is required!'
+    };
+  } else if (value.length < 10) {
+    return {
+      validate: false,
+      tip: 'Job Name length must great 10 char'
+    };
+  }
+  return true;
+}
+
+export default class ValidatorRowNotifierTable extends React.Component {
+  render() {
+    return (
+      <BootstrapTable data={ jobs } cellEdit={ cellEditProp } insertRow={ true }>
+          <TableHeaderColumn dataField='id' isKey={ true }>Job ID</TableHeaderColumn>
+          <TableHeaderColumn dataField='name' editable={ { validator: jobNameValidator } }>Job Name</TableHeaderColumn>
+          <TableHeaderColumn dataField='type' editable={ { type: 'select', options: { values: jobTypes } } }>Job Type</TableHeaderColumn>
+          <TableHeaderColumn dataField='active' editable={ { type: 'checkbox', options: { values: 'Y:N' } } }>Active</TableHeaderColumn>
+      </BootstrapTable>
+    );
+  }
+}

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -16,7 +16,9 @@ const editor = function(editable, attr, format, editorClass, defaultValue, ignor
           disabled='disabled'
           className={ ( editorClass || '') + ' form-control editor edit-text' } />
     );
-  } else if (editable && editable.type === undefined) {
+  } else if (editable && (editable.type === undefined ||
+             editable.type === null ||
+             editable.type.trim() === '')) {
     const type = editable ? 'text' : editable;
     return (
       <input { ...attr } type={ type } defaultValue={ defaultValue }

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -16,6 +16,12 @@ const editor = function(editable, attr, format, editorClass, defaultValue, ignor
           disabled='disabled'
           className={ ( editorClass || '') + ' form-control editor edit-text' } />
     );
+  } else if (editable && editable.type === undefined) {
+    const type = editable ? 'text' : editable;
+    return (
+      <input { ...attr } type={ type } defaultValue={ defaultValue }
+        className={ ( editorClass || '') + ' form-control editor edit-text' } />
+    );
   } else if (editable.type) {// standard declare
     // put style if exist
     editable.style && (attr.style = editable.style);

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -43,7 +43,6 @@ class TableBody extends Component {
           const format = column.format ? function(value) {
             return column.format(value, data, column.formatExtraData).replace(/<.*?>/g, '');
           } : false;
-
           if (isFun(column.editable)) {
             editable = column.editable(fieldValue, data, r, i);
           }

--- a/src/TableEditColumn.js
+++ b/src/TableEditColumn.js
@@ -44,8 +44,11 @@ class TableEditColumn extends Component {
     const ts = this;
     if (ts.props.editable.validator) {
       const valid = ts.props.editable.validator(value);
-      if (!valid) {
-        ts.refs.notifier.notice('error', valid, 'Pressed ESC can cancel');
+      if (!valid || (valid && typeof valid === 'object')) {
+        const isObject = (typeof valid === 'object');
+        const tip = isObject ? valid.tip : valid;
+        const validate = isObject ? valid.validate : false;
+        ts.refs.notifier.notice('error', tip, 'Pressed ESC can cancel');
         const input = ts.refs.inputRef;
         // animate input
         ts.clearTimeout();
@@ -54,7 +57,7 @@ class TableEditColumn extends Component {
           ts.setState({ shakeEditor: false });
         }, 300);
         input.focus();
-        return false;
+        return validate;
       }
     }
     return true;

--- a/src/toolbar/ToolBar.js
+++ b/src/toolbar/ToolBar.js
@@ -64,7 +64,10 @@ class ToolBar extends Component {
         }
 
         if (column.editable && column.editable.validator) { // process validate
-          tempMsg = column.editable.validator(tempValue);
+          const isObject = (typeof column.editable.validator(tempValue) === 'object');
+          tempMsg = isObject ?
+                    column.editable.validator(tempValue).tip :
+                    column.editable.validator(tempValue);
           if (tempMsg !== true) {
             isValid = false;
             validateState[column.field] = tempMsg;


### PR DESCRIPTION
Hi, This is the fixed for #398 

BTW this time I added a little features for table row validator notifier, if you want to use the notifier for table text field, but must be use object like:
```javascript
function jobNameValidator(value) {
  if (!value) {
    return {
      validate: false,
      tip: 'Job Name is required!'
    };
  } else if (value.length < 10) {
    return {
      validate: false,
      tip: 'Job Name length must great 10 char'
    };
  }
  return true;
}
```
and the notifier work on table row.
or see the example /examples/js/advance/validator-row-notifier-table.js

I didn't fine other bug for it now, but maybe it will affect other features..