### PR TITLE
Fix filter default value

### DIFF
--- a/src/filters/Date.js
+++ b/src/filters/Date.js
@@ -62,7 +62,7 @@ class DateFilter extends Component {
 
   componentDidMount() {
     const comparator = this.refs.dateFilterComparator.value;
-    const dateValue = this.refs.inputDate.defaultValue;
+    const dateValue = this.refs.inputDate.value;
     if (comparator && dateValue) {
       this.props.filterHandler({ date: new Date(dateValue), comparator }, Const.FILTER_TYPE.DATE);
     }

--- a/src/filters/Regex.js
+++ b/src/filters/Regex.js
@@ -19,7 +19,7 @@ class RegexFilter extends Component {
   }
 
   componentDidMount() {
-    const value = this.refs.inputText.defaultValue;
+    const value = this.refs.inputText.value;
     if (value) {
       this.props.filterHandler(value, Const.FILTER_TYPE.REGEX);
     }

--- a/src/filters/Text.js
+++ b/src/filters/Text.js
@@ -19,7 +19,7 @@ class TextFilter extends Component {
   }
 
   componentDidMount() {
-    const defaultValue = this.refs.inputText.defaultValue;
+    const defaultValue = this.refs.inputText.value;
     if (defaultValue) {
       this.props.filterHandler(defaultValue, Const.FILTER_TYPE.TEXT);
     }


### PR DESCRIPTION
When the component checks whether there is a default filter applied, it fetches the value from defaultValue.
This does not work. defaultValue on the input component is empty.
The value property however, contains the correct value.

Without this fix, the defaultValue property for the filter is not applied for text, regex and dates