### PR TITLE
React 15 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "history": "1.17.0",
     "jquery": "^2.1.4",
     "jsx-loader": "^0.13.2",
-    "react": "^0.14.3",
+    "react": "^0.14.3 || ^15.0.0",
     "react-bootstrap": "^0.27.2",
-    "react-dom": "^0.14.3",
+    "react-dom": "^0.14.3 || ^15.0.0",
     "react-hot-loader": "^1.3.0",
     "react-router": "^1.0.2",
     "react-router-bootstrap": "^0.19.2",
@@ -69,7 +69,7 @@
     "react-toastr": "^2.3.1"
   },
   "peerDependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3 || ^15.0.0"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/preprocessor.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap-table",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "It's a react table for bootstrap",
   "main": "./dist/react-bootstrap-table.min.js",
   "repository": {


### PR DESCRIPTION
Adds React 15 as a dependency, so now it's possible to either depend on React 0.14 or 15.0. Closes #397 and #419 