### PR TITLE
Add support for pagination start index

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,7 @@
     "react/sort-comp": 0,
     "react/jsx-no-bind": 0,
     "react/jsx-boolean-value": 0,
-
+    "eqeqeq": [2, "smart"],
     "quotes": [2, "single", "avoid-escape"],
     "jsx-quotes": [2, "prefer-single"],
     "comma-dangle": [2, "never"],

--- a/examples/js/pagination/custom-pagination-table.js
+++ b/examples/js/pagination/custom-pagination-table.js
@@ -25,6 +25,7 @@ export default class CustomPaginationTable extends React.Component {
       page: 2,  // which page you want to show as default
       sizePerPageList: [ 5, 10 ], // you can change the dropdown list for size per page
       sizePerPage: 5,  // which size per page you want to locate as default
+      pageStartIndex: 0, // where to start counting the pages
       paginationSize: 3,  // the pagination bar size.
       prePage: 'Prev', // Previous page button text
       nextPage: 'Next', // Next page button text

--- a/examples/js/remote/remote-paging.js
+++ b/examples/js/remote/remote-paging.js
@@ -13,6 +13,7 @@ export default class RemotePaging extends React.Component {
                       options={ { sizePerPage: this.props.sizePerPage,
                                   onPageChange: this.props.onPageChange,
                                   sizePerPageList: [ 5, 10 ],
+                                  pageStartIndex: 0,
                                   page: this.props.currentPage,
                                   onSizePerPageList: this.props.onSizePerPageList } }>
         <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,15 @@ gulp.task('example-server', function() {
     headers: {
       'Access-Control-Allow-Origin': '*'
     },
+    stats: {
+      assets: true,
+      colors: true,
+      version: false,
+      hash: false,
+      timings: true,
+      chunks: true,
+      chunkModules: false
+    },
     historyApiFallback: true
   }).listen(exampleConfig.serverConfig.port, 'localhost', function(err, result) {
     if (err) {

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -142,7 +142,13 @@ class BootstrapTable extends Component {
     const { options, selectRow } = nextProps;
 
     this.store.setData(nextProps.data.slice());
-    let page = options.page || this.state.currPage;
+
+    let page;
+    if (options.page !== 'undefined') {
+      page = options.page;
+    } else {
+      page = this.state.page;
+    }
 
     if (this.isRemoteDataSource()) {
       this.setState({

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -144,7 +144,7 @@ class BootstrapTable extends Component {
     this.store.setData(nextProps.data.slice());
 
     let page;
-    if (options.page !== 'undefined') {
+    if (options.page != null) {
       page = options.page;
     } else {
       page = this.state.currPage;
@@ -399,7 +399,7 @@ class BootstrapTable extends Component {
         isSelected ? this.store.get() : []);
     }
 
-    if (typeof result === 'undefined' || result !== false) {
+    if (typeof result == 'undefined' || result !== false) {
       if (isSelected) {
         selectedRowKeys = this.store.getAllRowkey();
       }

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -39,7 +39,9 @@ class BootstrapTable extends Component {
 
     this.state = {
       data: this.getTableData(),
-      currPage: this.props.options.page || 1,
+      currPage: this.props.options.page ||
+                this.props.options.pageStartIndex ||
+                Const.PAGE_START_INDEX,
       sizePerPage: this.props.options.sizePerPage || Const.SIZE_PER_PAGE_LIST[0],
       selectedRowKeys: this.store.getSelectedRowKeys()
     };
@@ -411,7 +413,7 @@ class BootstrapTable extends Component {
     }
     this.setState({
       data: result,
-      currPage: 1
+      currPage: this.props.options.pageStartIndex || Const.PAGE_START_INDEX
     });
   }
 
@@ -585,7 +587,7 @@ class BootstrapTable extends Component {
     }
 
     this.setState({
-      currPage: 1
+      currPage: this.props.options.pageStartIndex || Const.PAGE_START_INDEX
     });
 
     if (this.isRemoteDataSource()) {
@@ -655,7 +657,7 @@ class BootstrapTable extends Component {
     }
 
     this.setState({
-      currPage: 1
+      currPage: this.props.options.pageStartIndex || Const.PAGE_START_INDEX
     });
 
     if (this.isRemoteDataSource()) {

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -323,7 +323,7 @@ class BootstrapTable extends Component {
   }
 
   handlePaginationData = (page, sizePerPage) => {
-    const { onPageChange } = this.props.options;
+    const { onPageChange, pageStartIndex } = this.props.options;
     if (onPageChange) {
       onPageChange(page, sizePerPage);
     }
@@ -337,10 +337,19 @@ class BootstrapTable extends Component {
       return;
     }
 
-    const result = this.store.page(page, sizePerPage).get();
-    this.setState({
-      data: result
-    });
+    // We calculate an offset here in order to properly fetch the indexed data,
+    // despite the page start index not always being 1
+    let normalizedPage;
+    if (pageStartIndex !== undefined) {
+      const offset = Math.abs(Const.PAGE_START_INDEX - pageStartIndex);
+      normalizedPage = page + offset;
+    } else {
+      normalizedPage = page;
+    }
+
+    const result = this.store.page(normalizedPage, sizePerPage).get();
+
+    this.setState({ data: result });
   }
 
   handleMouseLeave = () => {
@@ -691,6 +700,7 @@ class BootstrapTable extends Component {
             changePage={ this.handlePaginationData.bind(this) }
             sizePerPage={ this.state.sizePerPage }
             sizePerPageList={ options.sizePerPageList || Const.SIZE_PER_PAGE_LIST }
+            pageStartIndex={ options.pageStartIndex }
             paginationShowsTotal={ options.paginationShowsTotal }
             paginationSize={ options.paginationSize || Const.PAGINATION_SIZE }
             remote={ this.isRemoteDataSource() }
@@ -907,6 +917,7 @@ BootstrapTable.propTypes = {
     afterColumnFilter: PropTypes.func,
     onRowClick: PropTypes.func,
     page: PropTypes.number,
+    pageStartIndex: PropTypes.number,
     paginationShowsTotal: PropTypes.bool,
     sizePerPageList: PropTypes.array,
     sizePerPage: PropTypes.number,
@@ -1003,6 +1014,7 @@ BootstrapTable.defaultProps = {
     nextPage: Const.NEXT_PAGE,
     firstPage: Const.FIRST_PAGE,
     lastPage: Const.LAST_PAGE,
+    pageStartIndex: undefined,
     searchDelayTime: undefined,
     exportCSVText: Const.EXPORT_CSV_TEXT,
     insertText: Const.INSERT_BTN_TEXT,

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -147,7 +147,7 @@ class BootstrapTable extends Component {
     if (options.page !== 'undefined') {
       page = options.page;
     } else {
-      page = this.state.page;
+      page = this.state.currPage;
     }
 
     if (this.isRemoteDataSource()) {

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -699,7 +699,7 @@ class BootstrapTable extends Component {
           <PaginationList
             ref='pagination'
             currPage={ this.state.currPage }
-            changePage={ this.handlePaginationData.bind(this) }
+            changePage={ this.handlePaginationData }
             sizePerPage={ this.state.sizePerPage }
             sizePerPageList={ options.sizePerPageList || Const.SIZE_PER_PAGE_LIST }
             pageStartIndex={ options.pageStartIndex }

--- a/src/Const.js
+++ b/src/Const.js
@@ -6,6 +6,7 @@ export default {
   LAST_PAGE: '>>',
   PRE_PAGE: '<',
   FIRST_PAGE: '<<',
+  PAGE_START_INDEX: 1,
   ROW_SELECT_BG_COLOR: '',
   ROW_SELECT_NONE: 'none',
   ROW_SELECT_SINGLE: 'radio',

--- a/src/pagination/PaginationList.js
+++ b/src/pagination/PaginationList.js
@@ -5,15 +5,24 @@ import Const from '../Const';
 class PaginationList extends Component {
 
   changePage = page => {
-    const { prePage, currPage, nextPage, lastPage, firstPage, sizePerPage } = this.props;
+    const {
+      pageStartIndex,
+      prePage,
+      currPage,
+      nextPage,
+      lastPage,
+      firstPage,
+      sizePerPage
+    } = this.props;
+
     if (page === prePage) {
-      page = currPage - 1 < 1 ? 1 : currPage - 1;
+      page = (currPage - 1) < pageStartIndex ? pageStartIndex : currPage - 1;
     } else if (page === nextPage) {
-      page = currPage + 1 > this.totalPages ? this.totalPages : currPage + 1;
+      page = (currPage + 1) > this.totalPages ? this.totalPages : currPage + 1;
     } else if (page === lastPage) {
       page = this.totalPages;
     } else if (page === firstPage) {
-      page = 1;
+      page = pageStartIndex;
     } else {
       page = parseInt(page, 10);
     }
@@ -40,7 +49,15 @@ class PaginationList extends Component {
   }
 
   render() {
-    const { currPage, dataSize, sizePerPage, sizePerPageList, paginationShowsTotal } = this.props;
+    const {
+      currPage,
+      dataSize,
+      sizePerPage,
+      sizePerPageList,
+      paginationShowsTotal,
+      pageStartIndex
+    } = this.props;
+
     this.totalPages = Math.ceil(dataSize / sizePerPage);
     const pageBtns = this.makePage();
     const pageListStyle = {
@@ -58,9 +75,11 @@ class PaginationList extends Component {
         </li>
       );
     });
+
+    const offset = Math.abs(Const.PAGE_START_INDEX - pageStartIndex);
     const total = paginationShowsTotal ? <span>
-      Showing rows { (currPage - 1) * sizePerPage + 1 } to&nbsp;
-      { Math.min(currPage * sizePerPage, dataSize) } of&nbsp;
+      Showing rows { ((currPage - pageStartIndex) * sizePerPage) } to&nbsp;
+      { Math.min((sizePerPage * (currPage + offset) - 1), dataSize) } of&nbsp;
       { dataSize }
     </span> : null;
 
@@ -113,7 +132,7 @@ class PaginationList extends Component {
       const isActive = page === this.props.currPage;
       let disabled = false;
       let hidden = false;
-      if (this.props.currPage === 1 &&
+      if (this.props.currPage === this.props.pageStartIndex &&
         (page === this.props.firstPage || page === this.props.prePage)) {
         disabled = true;
         hidden = true;
@@ -137,10 +156,11 @@ class PaginationList extends Component {
 
   getPages() {
     let pages;
-    let startPage = 1;
     let endPage = this.totalPages;
-
-    startPage = Math.max(this.props.currPage - Math.floor(this.props.paginationSize / 2), 1);
+    let startPage = Math.max(
+      this.props.currPage - Math.floor(this.props.paginationSize / 2),
+      this.props.pageStartIndex
+    );
     endPage = startPage + this.props.paginationSize - 1;
 
     if (endPage > this.totalPages) {
@@ -148,7 +168,7 @@ class PaginationList extends Component {
       startPage = endPage - this.props.paginationSize + 1;
     }
 
-    if (startPage !== 1 && this.totalPages > this.props.paginationSize) {
+    if (startPage !== this.props.pageStartIndex && this.totalPages > this.props.paginationSize) {
       pages = [ this.props.firstPage, this.props.prePage ];
     } else if (this.totalPages > 1) {
       pages = [ this.props.prePage ];
@@ -157,7 +177,7 @@ class PaginationList extends Component {
     }
 
     for (let i = startPage; i <= endPage; i++) {
-      if (i > 0) pages.push(i);
+      if (i >= this.props.pageStartIndex) pages.push(i);
     }
 
     if (endPage !== this.totalPages) {
@@ -179,11 +199,13 @@ PaginationList.propTypes = {
   paginationSize: PropTypes.number,
   remote: PropTypes.bool,
   onSizePerPageList: PropTypes.func,
-  prePage: PropTypes.string
+  prePage: PropTypes.string,
+  pageStartIndex: PropTypes.number
 };
 
 PaginationList.defaultProps = {
-  sizePerPage: Const.SIZE_PER_PAGE
+  sizePerPage: Const.SIZE_PER_PAGE,
+  pageStartIndex: Const.PAGE_START_INDEX
 };
 
 export default PaginationList;


### PR DESCRIPTION
I am using a service which uses 0-based indexing for paginating their API. I wanted a way in which I would simply map the state of my URL to params for their API. Rather than manually decrementing the `page` param each time I wanted to make an API, I think it would be cleaner, more robust, and simpler to maintain to simply allow for non-zero based indexing in react-bootstrap-table.

What this PR does is allow for the configuration option `pageStartIndex`. which allows the user to specify which page to begin paginating from.

If there is anything that needs to be changed, please let me know!

Cheers,
Ian