### PR TITLE
Fix for #506 impossible to filter in null values

### DIFF
--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -387,7 +387,9 @@ export class TableDataStore {
       let filterVal;
       for (const key in filterObj) {
         let targetVal = row[key];
-        if (targetVal === null) return false;
+        if (targetVal === null || targetVal === undefined) {
+          targetVal = '';
+        }
 
         switch (filterObj[key].type) {
         case Const.FILTER_TYPE.NUMBER: {


### PR DESCRIPTION
The fix for #427 (#428) is too aggressive in the sense that it prevents altogether to filter in a value of null.
Whatever the input in the filter input, it's impossible to include the line (it returns false systematically to the filter function on a null value)

I'd like to suggest a different fix. Instead of returning false, we set targetVal to the empty string in case the value is null or undefined. I believe this makes sense since the input from the user will be mostly text based (we could imagine custom filters for which it's not true) but in most cases it is. So assuming that having a value of null or undefined maps to an empty string seems sensible.

With that change, it becomes possible to filter in null values using the regex filter for instance and specifying a regex that only allows an empty string.