### PR TITLE
filter unmount change

### DIFF
--- a/src/TableHeaderColumn.js
+++ b/src/TableHeaderColumn.js
@@ -69,6 +69,10 @@ class TableHeaderColumn extends Component {
     this.refs['header-col'].setAttribute('data-field', this.props.dataField);
   }
 
+  componentWillUnmount() {
+    this.handleFilter();
+  }
+
   render() {
     let defaultCaret;
     const {


### PR DESCRIPTION
Hello! When TableHeaderColumns were unmounted, filters still continued working. Maybe this small fix can fix the situation.. )