### PR TITLE
improvement react-modal esc behavior

### DIFF
--- a/src/toolbar/ToolBar.js
+++ b/src/toolbar/ToolBar.js
@@ -109,6 +109,12 @@ class ToolBar extends Component {
     this.setState({ isInsertModalOpen: false });
   }
 
+  handleModalRequestClose = (modal) => {
+    return React.cloneElement(modal, {
+      onRequestClose: this.handleModalClose
+    });
+  }
+
   handleShowOnlyToggle = () => {
     this.setState({
       showSelected: !this.state.showSelected
@@ -218,9 +224,7 @@ class ToolBar extends Component {
     let modal = this.props.enableInsert ? this.renderInsertRowModal() : null;
 
     if (this.props.enableInsert) {
-      modal = React.cloneElement(modal, {
-        onRequestClose: this.handleModalClose
-      });
+      modal = this.handleModalRequestClose(modal);
     }
 
     return (

--- a/src/toolbar/ToolBar.js
+++ b/src/toolbar/ToolBar.js
@@ -215,7 +215,13 @@ class ToolBar extends Component {
     }
 
     const searchTextInput = this.renderSearchPanel();
-    const modal = this.props.enableInsert ? this.renderInsertRowModal() : null;
+    let modal = this.props.enableInsert ? this.renderInsertRowModal() : null;
+
+    if (this.props.enableInsert) {
+      modal = React.cloneElement(modal, {
+        onRequestClose: this.handleModalClose
+      });
+    }
 
     return (
       <div className='row'>
@@ -305,7 +311,7 @@ class ToolBar extends Component {
 
     return (
       <Modal className='react-bs-insert-modal modal-dialog'
-        isOpen={ this.state.isInsertModalOpen }>
+        isOpen={ this.state.isInsertModalOpen } >
         { modal }
       </Modal>
     );


### PR DESCRIPTION
Hi, @AllenFang 

I added the esc (close) behavior in ToolBar react-modal, and I would not to mutate the origin "modal" variant by just use React.cloneElement, I think maybe it can be friendly for user to switch it.