### PR TITLE
Add "defaultSearch" option in documentation

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -486,6 +486,8 @@
               <code>sortName</code>: The sort column name.</br>
               <code>sortOrder</code>: The sort ordering.</br>
             </div>
+            <font class="attr-lv1-title">defaultSearch</font> : <font class="attr-lv1-type">String</font></br>
+            <p>Manage search text by yourself.</p>
             <font class="attr-lv1-title">onSearchChange</font> : <font class="attr-lv1-type">Function</font></br>
             <p>Assign a callback function which will be called when search text change.</p>
             <p>This function taking three argument: <code>searchText</code>, <code>colInfos</code> and <code>multiColumnSearch</code></p>


### PR DESCRIPTION
BootstrapTable accepts "defaultSearch" option that's not mentioned in the docs