### PR TITLE
Remove console error for invalid regex

### DIFF
--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -338,7 +338,6 @@ export class TableDataStore {
     try {
       return new RegExp(filterVal, 'i').test(targetVal);
     } catch (e) {
-      console.error('Invalid regular expression');
       return true;
     }
   }


### PR DESCRIPTION
This could generate thousands of console messages for large dataset. Proposing we just remove the console error. 

/cc @AllenFang 