### PR TITLE
Add an option to make the tables printer friendly. Fixes issue #430

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -892,7 +892,8 @@ class BootstrapTable extends Component {
   }
 
   _adjustTable = () => {
-    this._adjustHeaderWidth();
+    if (!_this.props.printable)
+      this._adjustHeaderWidth();
     this._adjustHeight();
   }
 
@@ -987,6 +988,7 @@ BootstrapTable.propTypes = {
   hover: PropTypes.bool,
   condensed: PropTypes.bool,
   pagination: PropTypes.bool,
+  printable: PropTypes.bool,
   searchPlaceholder: PropTypes.string,
   selectRow: PropTypes.shape({
     mode: PropTypes.oneOf([
@@ -1084,6 +1086,7 @@ BootstrapTable.defaultProps = {
   hover: false,
   condensed: false,
   pagination: false,
+  printable: false,
   searchPlaceholder: undefined,
   selectRow: {
     mode: Const.ROW_SELECT_NONE,


### PR DESCRIPTION
This might not be optimal. If you just want the table headers to be the same size as the columns, it is fine. If you need scroll bars on your table, then it won't work. The two are mutually exclusive.