### PR TITLE
fixed #768 to filter number 0

### DIFF
--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -486,7 +486,11 @@ export class TableDataStore {
       // http://jsperf.com/for-vs-foreach/66
       for (let i = 0, keysLength = keys.length; i < keysLength; i++) {
         const key = keys[i];
-        if (this.colInfos[key] && row[key]) {
+        // fixed data filter when misunderstand 0 is false
+        let filterSpecialNum = false;
+        if (!isNaN(row[key]) &&
+          parseInt(row[key], 10) === 0) { filterSpecialNum = true; }
+        if (this.colInfos[key] && (row[key] || filterSpecialNum)) {
           const {
             format,
             filterFormatted,


### PR DESCRIPTION
fixed #768, This is my solution to avoid filter misunderstand 0 become false.

```
<BootstrapTable data={ products } search={ true } options={ options }>
  <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>
  <TableHeaderColumn dataField='name' searchable={ false }>Fruit Name</TableHeaderColumn>
  <TableHeaderColumn dataField='price' searchable={ false }>Product Price</TableHeaderColumn>
</BootstrapTable>
```

when id equals number 0 then filter can know it in this special case.