### PR TITLE
Add selectText as a new prop to the filter prop of SelectFilter

### DIFF
--- a/src/filters/Select.js
+++ b/src/filters/Select.js
@@ -34,9 +34,10 @@ class SelectFilter extends Component {
 
   getOptions() {
     const optionTags = [];
-    const { options, placeholder, columnName } = this.props;
+    const { options, placeholder, columnName, selectText } = this.props;
+    const selectTextValue = (selectText !== undefined) ? selectText : 'Select';
     optionTags.push((
-      <option key='-1' value=''>{ placeholder || `Select ${columnName}...` }</option>
+      <option key='-1' value=''>{ placeholder || `${selectTextValue} ${columnName}...` }</option>
     ));
     Object.keys(options).map(key => {
       optionTags.push(<option key={ key } value={ key }>{ options[key] + '' }</option>);


### PR DESCRIPTION
Add selectText as a new prop to the filter prop.
This is needed if we want to customize the "Select" word to a word in another language, for example.

An example for usage - change the word "Select" to "Choose":

```
<TableHeaderColumn ref='nameCol' dataField='quality' filterFormatted dataFormat={ enumFormatter }
              formatExtraData={ qualityType } filter={ { type: 'SelectFilter', options: qualityType, selectText: 'Choose' } }>Product Quality</TableHeaderColumn>
```
