### PR TITLE
Throw errors instead of string literals

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -53,7 +53,7 @@ class BootstrapTable extends Component {
     React.Children.forEach(props.children, column => {
       if (column.props.isKey) {
         if (keyField) {
-          throw 'Error. Multiple key column be detected in TableHeaderColumn.';
+          throw new Error('Error. Multiple key column be detected in TableHeaderColumn.');
         }
         keyField = column.props.dataField;
       }
@@ -81,8 +81,8 @@ class BootstrapTable extends Component {
     }, {});
 
     if (!isKeyFieldDefined && !keyField) {
-      throw `Error. No any key column defined in TableHeaderColumn.
-            Use 'isKey={true}' to specify a unique column after version 0.5.4.`;
+      throw new Error(`Error. No any key column defined in TableHeaderColumn.
+            Use 'isKey={true}' to specify a unique column after version 0.5.4.`);
     }
 
     this.store.setProps({

--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -167,12 +167,12 @@ export class TableDataStore {
 
   addAtBegin(newObj) {
     if (!newObj[this.keyField] || newObj[this.keyField].toString() === '') {
-      throw `${this.keyField} can't be empty value.`;
+      throw new Error(`${this.keyField} can't be empty value.`);
     }
     const currentDisplayData = this.getCurrentDisplayData();
     currentDisplayData.forEach(function(row) {
       if (row[this.keyField].toString() === newObj[this.keyField].toString()) {
-        throw `${this.keyField} ${newObj[this.keyField]} already exists`;
+        throw new Error(`${this.keyField} ${newObj[this.keyField]} already exists`);
       }
     }, this);
     currentDisplayData.unshift(newObj);
@@ -184,12 +184,12 @@ export class TableDataStore {
 
   add(newObj) {
     if (!newObj[this.keyField] || newObj[this.keyField].toString() === '') {
-      throw `${this.keyField} can't be empty value.`;
+      throw new Error(`${this.keyField} can't be empty value.`);
     }
     const currentDisplayData = this.getCurrentDisplayData();
     currentDisplayData.forEach(function(row) {
       if (row[this.keyField].toString() === newObj[this.keyField].toString()) {
-        throw `${this.keyField} ${newObj[this.keyField]} already exists`;
+        throw new Error(`${this.keyField} ${newObj[this.keyField]} already exists`);
       }
     }, this);
 


### PR DESCRIPTION
Throwing literals can mess up the stack trace and produce weird bugs. I forgot to add an unique key and [redbox](https://github.com/commissure/redbox-react) got messed up and was quite hard to find the actual error.

http://eslint.org/docs/rules/no-throw-literal
http://www.devthought.com/2011/12/22/a-string-is-not-an-error/