### PR TITLE
Fix #918

### DIFF
--- a/src/TableHeader.js
+++ b/src/TableHeader.js
@@ -32,8 +32,9 @@ class TableHeader extends Component {
       'table-condensed': this.props.condensed
     }, this.props.tableHeaderClass);
 
-    const rowCount = Math.max(React.Children.map(this.props.children, elm =>
-      Number(elm.props.row)));
+    const rowCount = Math.max(...React.Children.map(this.props.children, elm =>
+      elm.props.row ? Number(elm.props.row) : 0
+    ));
 
     const rows = [];
     let rowKey = 0;


### PR DESCRIPTION
Sorry that I made two stupid mistakes that results in `rowCount` equals to `NaN`. I had it fixed and shall be fine right now, please check.
Besides, I wondered if it is necessary to add default value and prop type for `TableHeaderColumn.row`?
Thank you.