### PR TITLE
Adding support for styled-components

### DIFF
--- a/examples/js/expandRow/demo.js
+++ b/examples/js/expandRow/demo.js
@@ -1,6 +1,6 @@
 /* eslint max-len: 0 */
 import React from 'react';
-import ExpandRow from './ExpandRow';
+import ExpandRow from './expandRow';
 import ExpandByColumn from './expand-row-by-column';
 import ExpandWithSelection from './expand-row-with-selection';
 import renderLinks from '../utils';

--- a/examples/js/style/demo.js
+++ b/examples/js/style/demo.js
@@ -8,6 +8,7 @@ import TdClassFunctionTable from './td-class-function-table';
 import EditTdClassTable from './edit-td-class-table';
 import InlineStylingTable from './inline-style-table';
 import TableClassTable from './table-class-table';
+import StyledComponentTable from './table-styled-components';
 
 class Demo extends React.Component {
   render() {
@@ -73,6 +74,15 @@ class Demo extends React.Component {
             <div className='panel-body'>
               <h5>Source in /examples/js/style/inline-style-table.js</h5>
               <InlineStylingTable />
+            </div>
+          </div>
+        </div>
+        <div className='col-md-offset-1 col-md-8'>
+          <div className='panel panel-default'>
+            <div className='panel-heading'>Support <a href='https://github.com/styled-components/styled-components' target='_blank'>styled-components</a></div>
+            <div className='panel-body'>
+              <h5>Source in /examples/js/style/table-styled-components.js</h5>
+              <StyledComponentTable />
             </div>
           </div>
         </div>

--- a/examples/js/style/table-styled-components.js
+++ b/examples/js/style/table-styled-components.js
@@ -1,0 +1,50 @@
+/* eslint max-len: 0 */
+/* eslint no-unused-vars: 0 */
+import React from 'react';
+import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
+import styled from 'styled-components';
+
+
+const products = [];
+
+function addProducts(quantity) {
+  const startId = products.length;
+  for (let i = 0; i < quantity; i++) {
+    const id = startId + i;
+    products.push({
+      id: id,
+      name: 'Item name ' + id,
+      price: 2100 + i
+    });
+  }
+}
+
+addProducts(5);
+
+class Table extends React.Component {
+  render() {
+    return (
+      <BootstrapTable data={ products } insertRow exportCSV
+          className={ this.props.className }
+          containerClass='my-container-class'
+          tableContainerClass='my-table-container-class'>
+          <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>
+          <TableHeaderColumn dataField='name'>Product Name</TableHeaderColumn>
+          <TableHeaderColumn dataField='price'>Product Price</TableHeaderColumn>
+      </BootstrapTable>
+    );
+  }
+}
+
+
+const StyledTable = styled(Table)`
+  th {
+    color: pink;
+  }
+
+  td {
+    color: blue;
+  }
+`;
+
+export default StyledTable;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "react-router": "^3.0.0",
     "style-loader": "^0.13.0",
+    "styled-components": "^1.2.1",
     "toastr": "^2.1.2",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.0.0",

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -280,7 +280,7 @@ class BootstrapTable extends Component {
     const showPaginationOnBottom = paginationPosition !== Const.PAGINATION_POS_TOP;
 
     return (
-      <div className={ classSet('react-bs-table-container', this.props.containerClass) }
+      <div className={ classSet('react-bs-table-container', this.props.className, this.props.containerClass) }
         style={ this.props.containerStyle }>
         { toolBar }
         { showPaginationOnTop ? pagination : null }


### PR DESCRIPTION
[Styled components](https://github.com/styled-components/styled-components) is a package to style components with _CSS in JS_ concepts. 

As explained in their [docs](https://github.com/styled-components/styled-components#third-party-components),  the only requirement to use styled-components with third-party components is the following:

> Note: styled-components generate a real stylesheet with classes. The class names are then passed to the react component (including third party components) via the className prop. For the styles to be applied, third-party components must attach the passed-in className prop to a DOM node.

You only need to pass `this.props.Classname` to the wrapper div's className prop on `BoostrapTable.js`. 

```javascript
classSet('react-bs-table-container', this.props.className, this.props.containerClass)
```

This is fully compatible with all react-bootstrap-table's customizable classes.
