### PR TITLE
Fixed sorting bug for multi column sort

### DIFF
--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -57,8 +57,8 @@ export class TableDataStore {
       if (order.length !== sortField.length) {
         throw new Error('The length of sort fields and orders should be equivalent');
       }
-      order = order.reverse();
-      this.sortList = sortField.reverse().map((field, i) => {
+      order = order.slice().reverse();
+      this.sortList = sortField.slice().reverse().map((field, i) => {
         return {
           order: order[i],
           sortField: field


### PR DESCRIPTION
There was a bug in multi column sort where the orders and sort fields  would be reversed on table redraws without the user changing the sort info. This was because array.reverse() was used which changes the underlying array. Applying slice().reverse() first makes a copy of the original array and then returns the reverse of it, leaving the original arrays in a correct state.