### PR TITLE
fix an exception if table source data is immutable type

### DIFF
--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -169,15 +169,19 @@ class TableBody extends Component {
       }
       return (result);
     }, this);
+
+    var tableRowsOutput = tableRows;
+    
     if (tableRows.length === 0 && !this.props.withoutNoDataText) {
-      tableRows.push(
-        <TableRow key='##table-empty##'>
-          <td data-toggle='collapse'
-              colSpan={ this.props.columns.length + (isSelectRowDefined ? 1 : 0) }
-              className='react-bs-table-no-data'>
-              { this.props.noDataText || Const.NO_DATA_TEXT }
-          </td>
-        </TableRow>
+      tableRowsOutput = [
+          <TableRow key='##table-empty##'>
+            <td data-toggle='collapse'
+                colSpan={ this.props.columns.length + (isSelectRowDefined ? 1 : 0) }
+                className='react-bs-table-no-data'>
+                { this.props.noDataText || Const.NO_DATA_TEXT }
+            </td>
+          </TableRow>
+        ]
       );
     }
 
@@ -188,7 +192,7 @@ class TableBody extends Component {
         <table className={ tableClasses }>
           { React.cloneElement(tableHeader, { ref: 'header' }) }
           <tbody ref='tbody'>
-            { tableRows }
+            { tableRowsOutput }
           </tbody>
         </table>
       </div>

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -170,19 +170,18 @@ class TableBody extends Component {
       return (result);
     }, this);
 
-    var tableRowsOutput = tableRows;
-    
+    let tableRowsOutput = tableRows;
+
     if (tableRows.length === 0 && !this.props.withoutNoDataText) {
       tableRowsOutput = [
-          <TableRow key='##table-empty##'>
-            <td data-toggle='collapse'
-                colSpan={ this.props.columns.length + (isSelectRowDefined ? 1 : 0) }
-                className='react-bs-table-no-data'>
-                { this.props.noDataText || Const.NO_DATA_TEXT }
-            </td>
-          </TableRow>
-        ]
-      );
+        <TableRow key='##table-empty##'>
+          <td data-toggle='collapse'
+              colSpan={ this.props.columns.length + (isSelectRowDefined ? 1 : 0) }
+              className='react-bs-table-no-data'>
+              { this.props.noDataText || Const.NO_DATA_TEXT }
+          </td>
+        </TableRow>
+      ];
     }
 
     return (


### PR DESCRIPTION
If table source data is built by immutable object list, e.g. by seamless-immutable or immutable-js library, the table will be broken if list is empty, which is caused by a push action to the list.

<img width="1277" alt="issue" src="https://cloud.githubusercontent.com/assets/11772378/23300050/dd3d55fc-fabe-11e6-9f07-81d038070878.png">
