### PR TITLE
Increase modal z-index.

### DIFF
--- a/css/react-bootstrap-table.css
+++ b/css/react-bootstrap-table.css
@@ -183,6 +183,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   background-color: rgba(0, 0, 0, 0.5);
+  z-index: 101;
 }
 
 .ReactModal__Overlay--after-open {


### PR DESCRIPTION
This prevents the New button from being above the Insert Modal (the second issue referenced in #1145).