### PR TITLE
Fixing problem with externally controlling expanded rows.

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -240,6 +240,14 @@ class BootstrapTable extends Component {
       });
     }
 
+    // If setting the expanded rows is being handled externally
+    // then overwrite the current expanded rows.
+    if (this.props.options.expanding !== options.expanding) {
+      this.setState({
+        expanding: options.expanding || []
+      });
+    }
+
     if (selectRow && selectRow.selected) {
       // set default select rows to store.
       const copy = selectRow.selected.slice();


### PR DESCRIPTION
Changing the "expanding" option was not changing which rows were selected. Setting an initial list of expanded rows worked, but modifying that list through the props to BootstrapTable did not work.

The value being passed down to TableBody is `this.state.expanding`, but that is only set from props as part of the constructor, so changes to props.options.expanding of an already mounted BootstrapTable weren't being taken into account.

I've added some handling in componentWillReceiveProps to deal with change to `options.expanding`. I've copied the pattern used for the pagination options.