### PR TITLE
Fix callback condition in Select filter

### DIFF
--- a/src/filters/Select.js
+++ b/src/filters/Select.js
@@ -21,10 +21,21 @@ class SelectFilter extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    function optionsEquals(options1, options2) {
+      const keys = Object.keys(options1);
+      for(let k in keys) {
+        if(options1[k] !== options2[k]) {
+          return false;
+        }
+      }
+      
+      return Object.keys(options1).length === Object.keys(options2).length
+    }
+    
     let needFilter = false;
     if (this.props.defaultValue !== prevProps.defaultValue) {
       needFilter = true;
-    } else if (this.props.options !== prevProps.options) {
+    } else if (!optionsEquals(this.props.options, prevProps.options)) {
       needFilter = true;
     }
     if (needFilter) {


### PR DESCRIPTION
The filter changed callback will be called less often, and in particular it will not be called when the options object has changed but has the same entries. This should fix issue #1187 

This is only a proposition, and other strategies are possible. In particular, I implemented the comparison function because the options object is always flat. It is also possible to use an external package like deep-equals or similar.