### PR TITLE
Restrict border & border-radius to bordered tables

### DIFF
--- a/css/react-bootstrap-table.css
+++ b/css/react-bootstrap-table.css
@@ -5,7 +5,7 @@
   margin-bottom: 0;
 }
 
-.react-bs-table {
+.react-bs-table-bordered {
   border: 1px solid #ddd;
   border-radius: 5px;
 }

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -355,7 +355,7 @@ class BootstrapTable extends Component {
         { toolBar }
         { showPaginationOnTop ? pagination : null }
         <div ref='table'
-            className={ classSet('react-bs-table', this.props.tableContainerClass) }
+            className={ classSet('react-bs-table', { 'react-bs-table-bordered': this.props.bordered }, this.props.tableContainerClass) }
             style={ { ...style, ...this.props.tableStyle } }
             onMouseEnter={ this.handleMouseEnter }
             onMouseLeave={ this.handleMouseLeave }>


### PR DESCRIPTION
As seen on the [Bootstrap table docs](http://getbootstrap.com/css/#tables), the default ("basic") style is a table without any borders, other than the border separating rows.

Therefore, tables generated with `react-boostrap-table` with borders disabled shouldn't have a border, either.

I didn't create an example for this (happy to if wanted), but this is what it looks like:

```jsx
<BootstrapTable data={ products } bordered={ false }>
...
```

<img width="698" alt="screenshot 2017-04-26 16 56 17" src="https://cloud.githubusercontent.com/assets/1441807/25456598/59d292e6-2aa1-11e7-844e-875fb85c014b.png">
