### PR TITLE
Maintain default bootstrap table margins

### DIFF
--- a/css/react-bootstrap-table.css
+++ b/css/react-bootstrap-table.css
@@ -22,16 +22,12 @@
   text-overflow: ellipsis;
 }
 
-.react-bs-table {
-  margin: 5px 10px 5px 10px;
-}
-
 .react-bs-table-pagination {
-  margin: 10px;
+  margin-top: 10px;
 }
 
 .react-bs-table-tool-bar {
-  margin: 10px 10px 0 10px;
+  margin-bottom: 5px;
 }
 
 .react-bs-container-header {

--- a/examples/js/style/style.css
+++ b/examples/js/style/style.css
@@ -1,3 +1,7 @@
+.react-bs-table-container {
+  margin: 5px 10px;
+}
+
 .tr-string-example{
     font-style: oblique;
     color: red;


### PR DESCRIPTION
Issue #414 touches on how this library adds margins surrounding the table, which was addressed in e60e607ca8a01ec89cd728196f083636bd7f99bf by allowing a `style="..."` override. However, I don't feel this is the right approach to this specific issue.

Bootstrap tables don’t have any surrounding margins by default*. Therefore when using this library to create bootstrap tables, there shouldn’t be any surrounding margins by default, either.

This PR maintains the intended margins between components inside react-bootstrap-table (such as the toolbar or pagination area), while removing the margin surrounding the table.

\* Bootstrap tables do have a margin-bottom of 20px that their docs override, however I don’t think this PR is the right place to address that.

Original "complex" example:
<img width="664" alt="screenshot 2017-04-26 17 30 31" src="https://cloud.githubusercontent.com/assets/1441807/25457985/239374ac-2aa6-11e7-88a3-89fa4abc08ee.png">

"Complex" example after these changes:
<img width="664" alt="screenshot 2017-04-26 17 30 10" src="https://cloud.githubusercontent.com/assets/1441807/25457992/2a6caf96-2aa6-11e7-92b9-66bcb1f6eabb.png">