### PR TITLE
Fix bug when default DateFilter and date editor are used together

### DIFF
--- a/examples/js/column-filter/all-filters.js
+++ b/examples/js/column-filter/all-filters.js
@@ -36,6 +36,10 @@ function enumFormatter(cell, row, enumObject) {
 }
 
 function dateFormatter(cell, row) {
+  if (typeof cell !== 'object') {
+    cell = new Date(cell);
+  }
+
   return `${('0' + cell.getDate()).slice(-2)}/${('0' + (cell.getMonth() + 1)).slice(-2)}/${cell.getFullYear()}`;
 }
 

--- a/examples/js/column-filter/date-filter-programmatically.js
+++ b/examples/js/column-filter/date-filter-programmatically.js
@@ -23,6 +23,10 @@ function addProducts(quantity) {
 addProducts(5);
 
 function dateFormatter(cell, row) {
+  if (typeof cell !== 'object') {
+    cell = new Date(cell);
+  }
+
   return `${('0' + cell.getDate()).slice(-2)}/${('0' + (cell.getMonth() + 1)).slice(-2)}/${cell.getFullYear()}`;
 }
 

--- a/examples/js/column-filter/date-filter-with-default-value.js
+++ b/examples/js/column-filter/date-filter-with-default-value.js
@@ -23,6 +23,10 @@ function addProducts(quantity) {
 addProducts(5);
 
 function dateFormatter(cell, row) {
+  if (typeof cell !== 'object') {
+    cell = new Date(cell);
+  }
+
   return `${('0' + cell.getDate()).slice(-2)}/${('0' + (cell.getMonth() + 1)).slice(-2)}/${cell.getFullYear()}`;
 }
 

--- a/examples/js/column-filter/date-filter.js
+++ b/examples/js/column-filter/date-filter.js
@@ -23,6 +23,10 @@ function addProducts(quantity) {
 addProducts(5);
 
 function dateFormatter(cell, row) {
+  if (typeof cell !== 'object') {
+    cell = new Date(cell);
+  }
+
   return `${('0' + cell.getDate()).slice(-2)}/${('0' + (cell.getMonth() + 1)).slice(-2)}/${cell.getFullYear()}`;
 }
 

--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -322,6 +322,10 @@ export class TableDataStore {
     const filterMonth = filterVal.getMonth();
     const filterYear = filterVal.getFullYear();
 
+    if (typeof targetVal !== 'object') {
+      targetVal = new Date(targetVal);
+    }
+
     const targetDate = targetVal.getDate();
     const targetMonth = targetVal.getMonth();
     const targetYear = targetVal.getFullYear();


### PR DESCRIPTION
When the DateFilter is used in conjunction with the builtin datetime field editor, TableDataStore.js throws an error. TableDataStore expects a Date, but the field editor (basically `<input type='datetime' />` returns a string. This needs to be checked for in TableDataStore.js, and the variable converted into a Date object if it's not already.

Along the same lines, the dateFormatter(cell, row) function in the examples also needs a similar check in order for both features (the date filter and date editor) to work together.