### PR TITLE
Fix Editor to use editable.type

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -105,7 +105,7 @@ const editor = function(editable, attr, format, editorClass, defaultValue, ignor
       );
     } else {// process other input type. as password,url,email...
       return (
-        <input { ...attr } type='text' defaultValue={ defaultValue }/>
+        <input { ...attr } type={ editable.type } defaultValue={ defaultValue }/>
       );
     }
   }


### PR DESCRIPTION
We can use only 4 types for editable type, `textarea`, `select`, `checkbox`, and `datetime`. and other types will be ignored.
doc: http://allenfang.github.io/react-bootstrap-table/docs.html#editable

This is because of this commit. [eslint on phase1](https://github.com/AllenFang/react-bootstrap-table/commit/e5310fa725f04c7d0290a4214326936c103512dc)

before: https://github.com/AllenFang/react-bootstrap-table/commit/e5310fa725f04c7d0290a4214326936c103512dc#diff-5b70bae4672cdf3d71d9f592ff139d08L78

```js
            //process other input type. as password,url,email...
            return(
                <input {...attr} type={type} defaultValue={defaultValue}/>
            )
```

after: https://github.com/AllenFang/react-bootstrap-table/commit/e5310fa725f04c7d0290a4214326936c103512dc#diff-5b70bae4672cdf3d71d9f592ff139d08R87

```js
      // process other input type. as password,url,email...
      return (
        <input { ...attr } type="text" defaultValue={ defaultValue }/>
      );
```

This PR will enable to use other input types like below.

```js
render() {
    return (
      <BootstrapTable data={ hoges } cellEdit={ cellEditProp } insertRow={ true }>
          <TableHeaderColumn dataField='hoge' editable={ { type: 'number' } }>Hoge</TableHeaderColumn>
      </BootstrapTable>
    );
  }
```