### PR TITLE
fix #1116 - iterate through real children

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -1271,12 +1271,17 @@ class BootstrapTable extends Component {
         }
       }
     } else {
-      React.Children.forEach(this.props.children.filter(_ => !!_), (child, i) => {
-        if (child.props.width) {
-          header[i].style.width = `${child.props.width}px`;
-          header[i].style.minWidth = `${child.props.width}px`;
+      for (const i in bodyHeader) {
+        if (bodyHeader.hasOwnProperty(i)) {
+          const child = bodyHeader[i];
+          if (child.style.width) {
+            header[i].style.width = child.style.width;
+          }
+          if (child.style.minWidth) {
+            header[i].style.minWidth = child.style.minWidth;
+          }
         }
-      });
+      }
     }
     this.isVerticalScroll = isScroll;
   }


### PR DESCRIPTION
Faced with almost the same issue [#1161](https://github.com/AllenFang/react-bootstrap-table/issues/1161) when my header is grouped.
As far as I have understood here we assign row's width to header's width.
Why not just to iterate through real rows instead of children, because some children in this case are just groupped-headers?