### PR TITLE
custom CSV separator (unable to use semicolon instead)

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -984,7 +984,7 @@ class BootstrapTable extends Component {
     } else {
       result = this.store.getDataIgnoringPagination();
     }
-
+    const separator = this.props.options.exportCSVSeparator || ',';
     const keys = [];
     this.props.children.filter(_ => _ != null).map(function(column) {
       if (column.props.export === true ||
@@ -1006,7 +1006,7 @@ class BootstrapTable extends Component {
       csvFileName = csvFileName();
     }
 
-    exportCSVUtil(result, keys, csvFileName);
+    exportCSVUtil(result, keys, csvFileName, separator);
   }
 
   handleSearch = searchText => {
@@ -1454,6 +1454,7 @@ BootstrapTable.propTypes = {
     lastPageTitle: PropTypes.string,
     searchDelayTime: PropTypes.number,
     exportCSVText: PropTypes.string,
+    exportCSVSeparator: PropTypes.string,
     insertText: PropTypes.string,
     deleteText: PropTypes.string,
     saveText: PropTypes.string,

--- a/src/csv_export_util.js
+++ b/src/csv_export_util.js
@@ -9,7 +9,7 @@ if (Util.canUseDOM()) {
   var saveAs = filesaver.saveAs;
 }
 
-function toString(data, keys) {
+function toString(data, keys, separator) {
   let dataString = '';
   if (data.length === 0) return dataString;
 
@@ -35,7 +35,7 @@ function toString(data, keys) {
       }
     }).filter(key => {
       return typeof key !== 'undefined';
-    }).join(',') + '\n';
+    }).join(separator) + '\n';
   }
 
   keys = keys.filter(key => {
@@ -48,7 +48,7 @@ function toString(data, keys) {
       const value = typeof format !== 'undefined' ? format(row[field], row, extraData) : row[field];
       const cell = typeof value !== 'undefined' ? ('"' + value + '"') : '';
       dataString += cell;
-      if (i + 1 < keys.length) dataString += ',';
+      if (i + 1 < keys.length) dataString += separator;
     });
 
     dataString += '\n';
@@ -57,8 +57,8 @@ function toString(data, keys) {
   return dataString;
 }
 
-const exportCSV = function(data, keys, filename) {
-  const dataString = toString(data, keys);
+const exportCSV = function(data, keys, filename, separator) {
+  const dataString = toString(data, keys, separator);
   if (typeof window !== 'undefined') {
     saveAs(new Blob([ dataString ],
         { type: 'text/plain;charset=utf-8' }),


### PR DESCRIPTION
Hello guys! I have amounts in my table that uses comma to separate decimal digits, so when exporting my data into CSV  I got some problems since **onExportToCSV** function uses a comma by default. here is a PR that adds  a new prop in options named **exportCSVSeparator**, that's comma by default and can be overridden in BootstrapTable.
I tested It locally and it works fine.
Thank you.