### PR TITLE
Fix 'undefined is not an object' when running in a headless browser

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -1347,11 +1347,13 @@ class BootstrapTable extends Component {
       for (const i in bodyHeader) {
         if (bodyHeader.hasOwnProperty(i)) {
           const child = bodyHeader[i];
-          if (child.style.width) {
-            header[i].style.width = child.style.width;
-          }
-          if (child.style.minWidth) {
-            header[i].style.minWidth = child.style.minWidth;
+          if (child.style) {
+            if (child.style.width) {
+              header[i].style.width = child.style.width;
+            }
+            if (child.style.minWidth) {
+              header[i].style.minWidth = child.style.minWidth;
+            }
           }
         }
       }


### PR DESCRIPTION
Here is fix so that react-bootstrap-table can run in a headless browser such as phantomjs or webkit #1429 

I just added a small check to the code in BootstrapTable.js to ensure that the child variable has a style object:

```
for (const i in bodyHeader) {
  if (bodyHeader.hasOwnProperty(i)) {
    const child = bodyHeader[i];
    if (child.style) {
      if (child.style.width) {
        header[i].style.width = child.style.width;
      }
      if (child.style.minWidth) {
        header[i].style.minWidth = child.style.minWidth;
      }
    }
  }
}
```

