### PR TITLE
Allow setting attributes on editable inputs

### DIFF
--- a/src/TableEditColumn.js
+++ b/src/TableEditColumn.js
@@ -169,7 +169,8 @@ class TableEditColumn extends Component {
       row
     } = this.props;
     const { shakeEditor } = this.state;
-    let attr = {
+    const attr = {
+      ...editable.attrs,
       ref: 'inputRef',
       onKeyDown: this.handleKeyPress,
       onBlur: this.handleBlur
@@ -179,7 +180,6 @@ class TableEditColumn extends Component {
     let { className } = this.state;
     // put placeholder if exist
     editable.placeholder && (attr.placeholder = editable.placeholder);
-    editable.attrs && (attr = {...editable.attrs, ...attr});
 
     const editorClass = classSet({ 'animated': shakeEditor, 'shake': shakeEditor });
     fieldValue = fieldValue === 0 ? '0' : fieldValue;

--- a/src/TableEditColumn.js
+++ b/src/TableEditColumn.js
@@ -169,7 +169,7 @@ class TableEditColumn extends Component {
       row
     } = this.props;
     const { shakeEditor } = this.state;
-    const attr = {
+    let attr = {
       ref: 'inputRef',
       onKeyDown: this.handleKeyPress,
       onBlur: this.handleBlur
@@ -179,6 +179,7 @@ class TableEditColumn extends Component {
     let { className } = this.state;
     // put placeholder if exist
     editable.placeholder && (attr.placeholder = editable.placeholder);
+    editable.attrs && (attr = {...editable.attrs, ...attr});
 
     const editorClass = classSet({ 'animated': shakeEditor, 'shake': shakeEditor });
     fieldValue = fieldValue === 0 ? '0' : fieldValue;

--- a/src/TableEditColumn.js
+++ b/src/TableEditColumn.js
@@ -148,14 +148,38 @@ class TableEditColumn extends Component {
   }
 
   focusInEditor() {
-    if (Util.isFunction(this.refs.inputRef.focus)) {
-      this.refs.inputRef.focus();
+    if (this.inputRef && Util.isFunction(this.inputRef.focus)) {
+      this.inputRef.focus();
     }
   }
 
   handleClick = e => {
     if (e.target.tagName !== 'TD') {
       e.stopPropagation();
+    }
+  }
+
+  getInputRef = userRef => ref => {
+    this.inputRef = ref;
+    if (typeof userRef === 'string') {
+      throw new Error('Ref must be a function');
+    }
+    if (Util.isFunction(userRef)) {
+      userRef(ref);
+    }
+  }
+
+  getHandleKeyPress = userHandler => e => {
+    this.handleKeyPress(e);
+    if (Util.isFunction(userHandler)) {
+      userHandler(e);
+    }
+  }
+
+  getHandleBlur = userHandler => e => {
+    this.handleBlur(e);
+    if (Util.isFunction(userHandler)) {
+      userHandler(e);
     }
   }
 
@@ -171,15 +195,21 @@ class TableEditColumn extends Component {
     const { shakeEditor } = this.state;
     const attr = {
       ...editable.attrs,
-      ref: 'inputRef',
-      onKeyDown: this.handleKeyPress,
-      onBlur: this.handleBlur
+      ref: this.getInputRef(editable.attrs && editable.attrs.ref),
+      onKeyDown: this.getHandleKeyPress(editable.attrs && editable.attrs.onKeyDown),
+      onBlur: this.getHandleBlur(editable.attrs && editable.attrs.onBlur)
     };
     let style = { position: 'relative' };
     let { fieldValue } = this.props;
     let { className } = this.state;
     // put placeholder if exist
-    editable.placeholder && (attr.placeholder = editable.placeholder);
+    if (editable.placeholder) {
+      attr.placeholder = editable.placeholder;
+      /* eslint-disable no-console */
+      console.warn(
+        'Setting editable.placeholder is deprecated. Use editable.attrs to set input attributes');
+      /* eslint-enable no-console */
+    }
 
     const editorClass = classSet({ 'animated': shakeEditor, 'shake': shakeEditor });
     fieldValue = fieldValue === 0 ? '0' : fieldValue;


### PR DESCRIPTION
I think it would be nice if there was an easy way to set attributes for editable inputs without having to create a customEditor. This allows stuff like:
```
editable={{type: 'number', attrs: {min: 1, max: 4, step: 1}}}
```
I'd only want it for simple attributes, but I don't like that it just silently ignores anything the user passes for ref, onKeyDown and onBlur and I'm not sure the best way to deal with it. Is it worth the extra code to support these, should ref and on* throw an error...?