### PR TITLE
Added prop defaultValue so users can display a default value for empty data

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -425,6 +425,7 @@ class BootstrapTable extends Component {
             tableBodyClass={ this.props.tableBodyClass }
             style={ { ...style, ...this.props.bodyStyle } }
             data={ this.state.data }
+            defaultValue={ this.props.defaultValue }
             expandComponent={ this.props.expandComponent }
             expandableRow={ this.props.expandableRow }
             expandRowBgColor={ this.props.options.expandRowBgColor }
@@ -1426,6 +1427,7 @@ BootstrapTable.propTypes = {
   height: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   maxHeight: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   data: PropTypes.oneOfType([ PropTypes.array, PropTypes.object ]),
+  defaultValue: PropTypes.string,
   remote: PropTypes.oneOfType([ PropTypes.bool, PropTypes.func ]), // remote data, default is false
   replace: PropTypes.oneOfType([ PropTypes.bool, PropTypes.func ]),
   scrollTop: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -109,6 +109,7 @@ class TableBody extends Component {
           } else {
             columnTitle = column.columnTitle && fieldValue ? fieldValue.toString() : null;
           }
+          if (!columnChild) { columnChild = this.props.defaultValue; }
           return (
             <TableColumn key={ i }
               rIndex={ r }
@@ -500,6 +501,7 @@ class TableBody extends Component {
 }
 TableBody.propTypes = {
   data: PropTypes.array,
+  defaultValue: PropTypes.string,
   columns: PropTypes.array,
   striped: PropTypes.bool,
   bordered: PropTypes.bool,


### PR DESCRIPTION
In some cases, the user may want to display a default value in the table if no data is available instead of a blank value. The user can add a 'defaultValue' prop to the BootstrapTable component if need be.