### PR TITLE
Add quotation marks to header cells on CSV export

### DIFF
--- a/src/csv_export_util.js
+++ b/src/csv_export_util.js
@@ -29,7 +29,7 @@ function toString(data, keys, separator, excludeCSVHeader) {
   for (let i = firstRow; i <= rowCount; i++) {
     dataString += headCells.map(x => {
       if ((x.row + (x.rowSpan - 1)) === i) {
-        return x.header;
+        return `"${x.header}"`;
       }
       if (x.row === i && x.rowSpan > 1) {
         return '';


### PR DESCRIPTION
You add quotations to avoid commas in cell values breaking the formatting in the line:

`var cell = typeof value !== 'undefined' ? '"' + value + '"' : '';`

but not in when exporting header cells, meaning that header cells which include commas are split when viewing the CSV file in programs like excel.