### PR TITLE
Changed isPlaceholderSelected check in componentWillReceiveProps

### DIFF
--- a/src/filters/Select.js
+++ b/src/filters/Select.js
@@ -23,7 +23,7 @@ class SelectFilter extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps() {
     const currentSelectValue = this.refs.selectInput.value;
     const isPlaceholderSelected = !currentSelectValue || currentSelectValue === '';
     this.setState(() => {

--- a/src/filters/Select.js
+++ b/src/filters/Select.js
@@ -24,8 +24,8 @@ class SelectFilter extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const isPlaceholderSelected = (nextProps.defaultValue === undefined ||
-      !nextProps.options.hasOwnProperty(nextProps.defaultValue));
+    const currentSelectValue = this.refs.selectInput.value;
+    const isPlaceholderSelected = !currentSelectValue || currentSelectValue === '';
     this.setState(() => {
       return {
         isPlaceholderSelected


### PR DESCRIPTION
IMO there is no need to check for defaultValue here. Just check for current selected value. Maybe this method can be removed, the state for isPlaceholderSelected is updated on every action in this class (f. e. filter, ...).
This fixes the github-issue #1568 - "placeholder-selected in filters/Select.js is not handled correctly" - (https://github.com/AllenFang/react-bootstrap-table/issues/1568)