### PR TITLE
Fix filters on dynamic columns update

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -57,6 +57,18 @@ class BootstrapTable extends Component {
   }
 
   initTable(props) {
+    // If columns changed, clean removed columns that had filters
+    if (props.children !== this.props.children && this.filter) {
+      const nextDataFields = props.children.map(column => column.props.dataField);
+      this.props.children.forEach(column => {
+        const { dataField, filter } = column.props;
+        if (!nextDataFields.includes(dataField)) {
+          // Clear filter
+          this.filter.handleFilter(dataField, '', filter.type, filter);
+        }
+      });
+    }
+
     let { keyField } = props;
 
     const isKeyFieldDefined = typeof keyField === 'string' && keyField.length;

--- a/src/TableHeaderColumn.js
+++ b/src/TableHeaderColumn.js
@@ -22,6 +22,19 @@ class TableHeaderColumn extends Component {
     if (nextProps.reset) {
       this.cleanFiltered();
     }
+
+    // If column not displaying the same dataField, reset the filter accordingly
+    if (nextProps.dataField !== this.props.dataField) {
+      const emitter = nextProps.filter.emitter || {};
+      const currentFilter = emitter.currentFilter || {};
+      const filter = currentFilter[nextProps.dataField];
+      const value = filter ? filter.value : '';
+
+      const { ref } = this.getFilters() || {};
+      if (this.refs[ref]) {
+        this.refs[ref].setState({ value });
+      }
+    }
   }
 
   handleColumnClick = () => {


### PR DESCRIPTION
Fixes #787 

**Problem:** dynamically changing the column set does not update the filters accordingly. As an example, if I'm filtering on column `A` and remove it from the column set, I'd like the internal data not to be filtered on `A` anymore.

**Solution:** the current implementation solves it in two steps:
1. `BootstrapTable.js` - internal filters: detect when a filtered column is removed, and clear column.
2. `TableHeaderColumn.js` - ui filters: detect when the `props.dataField` changes and update the underlying filter accordingly - explanations below.

Say you have a table with columns `A`, `B` and `C` with their underlying `TableHeaderColumn` instances `a`, `b` and `c` displaying them. If you remove column `B` and display only 2 columns, React will only use the first 2 component instances so that:
- `a` displays `A`
- `b` displays `C` !

This was causing UI inconsistencies, hence the 2nd check.

And FYI, this will also cover columns being moved around, e.g. swapping two dataFields.

**Implementation:** 

@AllenFang the current `setState` in `TableHeaderColumn.js` is a bit hacky, but I was trying to minimize the number of files I touched. Do you want to refactor that into a `setValue` method in each specialized Filter?