### PR TITLE
Add new FILTER_TYPE 'ArrayFilter' to allow filtering on multiple values

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -67,7 +67,7 @@ class BootstrapTable extends Component {
       }
       if (column.props.isKey) {
         if (keyField) {
-          throw new Error('Error. Multiple key column be detected in TableHeaderColumn.');
+          throw new Error('Error. Multiple key column detected in TableHeaderColumn.');
         }
         keyField = column.props.dataField;
       }
@@ -82,6 +82,7 @@ class BootstrapTable extends Component {
       }
     });
 
+    // if a column filter was created, add 'onFilterChange' listener
     if (this.filter) {
       this.filter.removeAllListeners('onFilterChange');
       this.filter.on('onFilterChange', (currentFilter) => {

--- a/src/Const.js
+++ b/src/Const.js
@@ -44,7 +44,8 @@ const CONST_VAR = {
     SELECT: 'SelectFilter',
     NUMBER: 'NumberFilter',
     DATE: 'DateFilter',
-    CUSTOM: 'CustomFilter'
+    CUSTOM: 'CustomFilter',
+    ARRAY: 'ArrayFilter'
   },
   FILTER_COND_EQ: 'eq',
   FILTER_COND_LIKE: 'like',

--- a/src/store/TableDataStore.js
+++ b/src/store/TableDataStore.js
@@ -436,6 +436,14 @@ export class TableDataStore {
     }
   }
 
+  /**
+   * Filter if targetVal is contained in filterVal.
+   */
+  filterArray(targetVal, filterVal) {
+    // case insensitive
+    return filterVal.indexOf(targetVal) > -1;
+  }
+
   /* General search function
    * It will search for the text if the input includes that text;
    */
@@ -488,6 +496,13 @@ export class TableDataStore {
           filterVal = filterObj[key].value;
           break;
         }
+        case Const.FILTER_TYPE.ARRAY: {
+          filterVal = filterObj[key].value;
+          if (!Array.isArray(filterVal)) {
+            throw new Error('Value must be an Array');
+          }
+          break;
+        }
         default: {
           filterVal = filterObj[key].value;
           if (filterVal === undefined) {
@@ -526,6 +541,10 @@ export class TableDataStore {
         case Const.FILTER_TYPE.CUSTOM: {
           const cond = filterObj[key].props ? filterObj[key].props.cond : Const.FILTER_COND_LIKE;
           valid = this.filterCustom(targetVal, filterVal, filterObj[key].value, cond);
+          break;
+        }
+        case Const.FILTER_TYPE.ARRAY: {
+          valid = this.filterArray(targetVal, filterVal);
           break;
         }
         default: {


### PR DESCRIPTION
This is workaround for issue #1202. It adds a new FILTER_TYPE called `ArrayFilter` for filtering multiple values.


@AllenFang I know you have focus development on react-boostrap-table2, but I think this would be a small but useful improvement.

```
export default class ProgrammaticallyArrayFilter extends React.Component {
  /* Filtering passing an array of values */
  handleBtnClick = () => {
    this.refs.table.handleFilterData({
      name: { type: 'ArrayFilter', value: [ 'Item name 3', 'Item name 4' ] },
      price: { type: 'ArrayFilter', value: [ 2100, 2104 ] }
    });
  }

  render() {
    return (
      <div>
        <button onClick={ this.handleBtnClick } className='btn btn-default'>Click to apply text filter</button>
        <BootstrapTable ref='table' data={ products }>
          <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>
          <TableHeaderColumn ref='nameCol' dataField='name' filter={ { type: 'TextFilter', delay: 1000 } }>Product Name</TableHeaderColumn>
          <TableHeaderColumn dataField='price'>Product Price</TableHeaderColumn>
        </BootstrapTable>
      </div>
    );
  }
}
```