### PR TITLE
Added new feature Expand/Collapse All Rows by using Header Column

### DIFF
--- a/css/react-bootstrap-table.css
+++ b/css/react-bootstrap-table.css
@@ -261,6 +261,11 @@ td.react-bs-table-expand-cell {
     cursor: pointer;
 }
 
+th.react-bs-table-expand-cell {
+  cursor: pointer;
+}
+
+
 @keyframes shake {
   from, to {
     transform: translate3d(0, 0, 0);

--- a/css/react-bootstrap-table.css
+++ b/css/react-bootstrap-table.css
@@ -261,7 +261,7 @@ td.react-bs-table-expand-cell {
     cursor: pointer;
 }
 
-th.react-bs-table-expand-cell {
+th.react-bs-table-expand-cell > div {
   cursor: pointer;
 }
 

--- a/examples/js/expandRow/custom-expand-indicator.js
+++ b/examples/js/expandRow/custom-expand-indicator.js
@@ -81,9 +81,19 @@ export default class ExpandRow extends React.Component {
     );
   }
 
+  expandedColumnHeaderComponent({ expandAllChilds }) {
+    const content = (expandAllChilds ? '(-)' : '(+)' );
+    return (
+      <div>
+        { content }
+      </div>
+    );
+  }
+
   render() {
     const options = {
-      expandRowBgColor: 'rgb(242, 255, 163)'
+      expandRowBgColor: 'rgb(242, 255, 163)',
+      expandAllChilds: false
     };
     return (
       <BootstrapTable data={ products }
@@ -93,7 +103,8 @@ export default class ExpandRow extends React.Component {
         expandColumnOptions={ {
           expandColumnVisible: true,
           expandColumnComponent: this.expandColumnComponent,
-          columnWidth: 50
+          columnWidth: 50,
+          expandedColumnHeaderComponent: this.expandedColumnHeaderComponent
         } }
         search>
         <TableHeaderColumn dataField='id' isKey={ true }>Product ID</TableHeaderColumn>

--- a/examples/js/expandRow/custom-expand-indicator.js
+++ b/examples/js/expandRow/custom-expand-indicator.js
@@ -93,7 +93,8 @@ export default class ExpandRow extends React.Component {
   render() {
     const options = {
       expandRowBgColor: 'rgb(242, 255, 163)',
-      expandAllChilds: false
+      expandAllChilds: false,
+      showExpandAllHeaderColumn: true
     };
     return (
       <BootstrapTable data={ products }

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -44,14 +44,24 @@ class BootstrapTable extends Component {
     this._adjustHeaderWidth = this._adjustHeaderWidth.bind(this);
     this._adjustHeight = this._adjustHeight.bind(this);
     this._adjustTable = this._adjustTable.bind(this);
+    this.toggleExpandAllChilds = this.toggleExpandAllChilds.bind(this);
+
+    let expandedKeys = [];
+    if (this.props.options.expandAllChilds !== null &&
+      this.props.options.expandAllChilds !== undefined && this.props.options.expandAllChilds) {
+      expandedKeys = this.store.getAllRowkey();
+    } else if (this.props.options.expanding !== undefined && this.props.options.expanding !== null) {
+      expandedKeys = this.props.options.expanding;
+    }
 
     this.state = {
       data: this.getTableData(),
       currPage: currPage,
-      expanding: this.props.options.expanding || [],
+      expanding: expandedKeys,
       sizePerPage: this.props.options.sizePerPage || Const.SIZE_PER_PAGE_LIST[0],
       selectedRowKeys: this.store.getSelectedRowKeys(),
       reset: false,
+      expandAllChilds: this.props.options.expandAllChilds,
       x: this.props.keyBoardNav ? 0 : -1,
       y: this.props.keyBoardNav ? 0 : -1
     };
@@ -467,6 +477,9 @@ class BootstrapTable extends Component {
             reset={ this.state.reset }
             expandColumnVisible={ expandColumnOptions.expandColumnVisible }
             expandColumnComponent={ expandColumnOptions.expandColumnComponent }
+            expandedColumnHeaderComponent={ expandColumnOptions.expandedColumnHeaderComponent }
+            expandAllChilds={ this.state.expandAllChilds }
+            toggleExpandAllChilds={ this.toggleExpandAllChilds }
             expandColumnBeforeSelectColumn={ expandColumnOptions.expandColumnBeforeSelectColumn }>
             { this.props.children }
           </TableHeader>
@@ -614,6 +627,28 @@ class BootstrapTable extends Component {
     this.setState(() => { return { expanding, reset: false }; }, () => {
       this._adjustHeaderWidth();
     });
+  }
+
+  toggleExpandAllChilds() {
+    const { expandAllChilds } = this.state;
+    const compScope = this;
+    if (expandAllChilds) {
+      this.setState(() => {
+        return {
+          expanding: [],
+          expandAllChilds: !expandAllChilds,
+          reset: false
+        };
+      });
+    } else {
+      this.setState(() => {
+        return {
+          expanding: compScope.store.getAllRowkey(),
+          expandAllChilds: !expandAllChilds,
+          reset: false
+        };
+      });
+    }
   }
 
   handlePaginationData = (page, sizePerPage) => {
@@ -1691,7 +1726,8 @@ BootstrapTable.propTypes = {
     beforeShowError: PropTypes.func,
     printToolBar: PropTypes.bool,
     insertFailIndicator: PropTypes.string,
-    noAutoBOM: PropTypes.bool
+    noAutoBOM: PropTypes.bool,
+    expandAllChilds: PropTypes.bool
   }),
   fetchInfo: PropTypes.shape({
     dataTotalSize: PropTypes.number
@@ -1710,6 +1746,7 @@ BootstrapTable.propTypes = {
     columnWidth: PropTypes.oneOfType([ PropTypes.number, PropTypes.string ]),
     expandColumnVisible: PropTypes.bool,
     expandColumnComponent: PropTypes.func,
+    expandedColumnHeaderComponent: PropTypes.func,
     expandColumnBeforeSelectColumn: PropTypes.bool
   }),
   footer: PropTypes.bool
@@ -1723,6 +1760,7 @@ BootstrapTable.defaultProps = {
   expandColumnOptions: {
     expandColumnVisible: false,
     expandColumnComponent: undefined,
+    expandedColumnHeaderComponent: undefined,
     expandColumnBeforeSelectColumn: true
   },
   height: '100%',
@@ -1858,7 +1896,8 @@ BootstrapTable.defaultProps = {
     beforeShowError: undefined,
     printToolBar: true,
     insertFailIndicator: Const.INSERT_FAIL_INDICATOR,
-    noAutoBOM: true
+    noAutoBOM: true,
+    expandAllChilds: false
   },
   fetchInfo: {
     dataTotalSize: 0

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -480,6 +480,7 @@ class BootstrapTable extends Component {
             expandedColumnHeaderComponent={ expandColumnOptions.expandedColumnHeaderComponent }
             expandAllChilds={ this.state.expandAllChilds }
             toggleExpandAllChilds={ this.toggleExpandAllChilds }
+            showExpandAllHeaderColumn={ this.props.options.showExpandAllHeaderColumn }
             expandColumnBeforeSelectColumn={ expandColumnOptions.expandColumnBeforeSelectColumn }>
             { this.props.children }
           </TableHeader>
@@ -1727,7 +1728,8 @@ BootstrapTable.propTypes = {
     printToolBar: PropTypes.bool,
     insertFailIndicator: PropTypes.string,
     noAutoBOM: PropTypes.bool,
-    expandAllChilds: PropTypes.bool
+    expandAllChilds: PropTypes.bool,
+    showExpandAllHeaderColumn: PropTypes.bool
   }),
   fetchInfo: PropTypes.shape({
     dataTotalSize: PropTypes.number
@@ -1897,7 +1899,8 @@ BootstrapTable.defaultProps = {
     printToolBar: true,
     insertFailIndicator: Const.INSERT_FAIL_INDICATOR,
     noAutoBOM: true,
-    expandAllChilds: false
+    expandAllChilds: false,
+    showExpandAllHeaderColumn: false
   },
   fetchInfo: {
     dataTotalSize: 0

--- a/src/ExpandRowHeaderColumn.js
+++ b/src/ExpandRowHeaderColumn.js
@@ -13,17 +13,23 @@ class ExpandRowHeaderColumn extends Component {
   }
 
   render() {
-    const { expandedColumnHeaderComponent, expandAllChilds } = this.props;
-    const defaultExpandedHeaderComponent = (expandAllChilds ? '(-)' : '(+)' );
+    const {
+      expandedColumnHeaderComponent,
+      expandAllChilds,
+      showExpandAllHeaderColumn
+    } = this.props;
+    const expandedHeaderComponent = (expandAllChilds ? '(-)' : '(+)' );
     const ExpandedColumnHeaderComponent = expandedColumnHeaderComponent;
 
     return (
       <th rowSpan={ this.props.rowCount } style={ { textAlign: 'center' } }
         className='react-bs-table-expand-cell'
-        data-is-only-head={ false } onClick={ this.toggleExpandAllChilds }>
-        { this.props.expandedColumnHeaderComponent ?
-          <ExpandedColumnHeaderComponent
-            expandAllChilds={ this.props.expandAllChilds } /> : defaultExpandedHeaderComponent }
+        data-is-only-head={ false }>
+        { showExpandAllHeaderColumn && <div onClick={ this.toggleExpandAllChilds }>
+          { expandedColumnHeaderComponent ?
+            <ExpandedColumnHeaderComponent
+              expandAllChilds={ this.props.expandAllChilds } /> : expandedHeaderComponent }
+        </div> }
       </th>
     );
   }
@@ -32,6 +38,7 @@ ExpandRowHeaderColumn.propTypes = {
   expandedColumnHeaderComponent: PropTypes.func,
   rowCount: PropTypes.number,
   expandAllChilds: PropTypes.bool,
-  toggleExpandAllChilds: PropTypes.func
+  toggleExpandAllChilds: PropTypes.func,
+  showExpandAllHeaderColumn: PropTypes.bool
 };
 export default ExpandRowHeaderColumn;

--- a/src/ExpandRowHeaderColumn.js
+++ b/src/ExpandRowHeaderColumn.js
@@ -3,18 +3,35 @@ import PropTypes from 'prop-types';
 
 class ExpandRowHeaderColumn extends Component {
 
+  constructor(props) {
+    super(props);
+    this.toggleExpandAllChilds = this.toggleExpandAllChilds.bind(this);
+  }
+
+  toggleExpandAllChilds() {
+    this.props.toggleExpandAllChilds();
+  }
+
   render() {
+    const { expandedColumnHeaderComponent, expandAllChilds } = this.props;
+    const defaultExpandedHeaderComponent = (expandAllChilds ? '(-)' : '(+)' );
+    const ExpandedColumnHeaderComponent = expandedColumnHeaderComponent;
+
     return (
       <th rowSpan={ this.props.rowCount } style={ { textAlign: 'center' } }
         className='react-bs-table-expand-cell'
-        data-is-only-head={ false }>
-        { this.props.children }
+        data-is-only-head={ false } onClick={ this.toggleExpandAllChilds }>
+        { this.props.expandedColumnHeaderComponent ?
+          <ExpandedColumnHeaderComponent
+            expandAllChilds={ this.props.expandAllChilds } /> : defaultExpandedHeaderComponent }
       </th>
     );
   }
 }
 ExpandRowHeaderColumn.propTypes = {
-  children: PropTypes.node,
-  rowCount: PropTypes.number
+  expandedColumnHeaderComponent: PropTypes.func,
+  rowCount: PropTypes.number,
+  expandAllChilds: PropTypes.bool,
+  toggleExpandAllChilds: PropTypes.func
 };
 export default ExpandRowHeaderColumn;

--- a/src/TableHeader.js
+++ b/src/TableHeader.js
@@ -39,7 +39,8 @@ class TableHeader extends Component {
 
   render() {
     const { sortIndicator, sortList, onSort, reset, version, condensed, bordered,
-      expandedColumnHeaderComponent, expandAllChilds, toggleExpandAllChilds } = this.props;
+      expandedColumnHeaderComponent, expandAllChilds, toggleExpandAllChilds,
+      showExpandAllHeaderColumn } = this.props;
     const containerClasses = classSet(
       'react-bs-container-header',
       'table-header-wrapper',
@@ -68,7 +69,8 @@ class TableHeader extends Component {
           <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }
             expandedColumnHeaderComponent={ expandedColumnHeaderComponent }
             expandAllChilds={ expandAllChilds }
-            toggleExpandAllChilds={ toggleExpandAllChilds }/>
+            toggleExpandAllChilds={ toggleExpandAllChilds }
+            showExpandAllHeaderColumn={ showExpandAllHeaderColumn }/>
     ], [
       this.renderSelectRowHeader(rowCount + 1, rowKey++)
     ], [
@@ -77,7 +79,8 @@ class TableHeader extends Component {
           <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }
             expandedColumnHeaderComponent={ expandedColumnHeaderComponent }
             expandAllChilds={ expandAllChilds }
-            toggleExpandAllChilds={ toggleExpandAllChilds }/>
+            toggleExpandAllChilds={ toggleExpandAllChilds }
+            showExpandAllHeaderColumn={ showExpandAllHeaderColumn }/>
     ]);
 
     React.Children.forEach(this.props.children, (elm) => {
@@ -177,7 +180,8 @@ TableHeader.propTypes = {
   expandColumnBeforeSelectColumn: PropTypes.bool,
   version: PropTypes.string,
   expandAllChilds: PropTypes.bool,
-  toggleExpandAllChilds: PropTypes.func
+  toggleExpandAllChilds: PropTypes.func,
+  showExpandAllHeaderColumn: PropTypes.bool
 };
 
 export default TableHeader;

--- a/src/TableHeader.js
+++ b/src/TableHeader.js
@@ -38,7 +38,8 @@ function getSortOrder(sortList, field, enableSort) {
 class TableHeader extends Component {
 
   render() {
-    const { sortIndicator, sortList, onSort, reset, version, condensed, bordered } = this.props;
+    const { sortIndicator, sortList, onSort, reset, version, condensed, bordered,
+      expandedColumnHeaderComponent, expandAllChilds, toggleExpandAllChilds } = this.props;
     const containerClasses = classSet(
       'react-bs-container-header',
       'table-header-wrapper',
@@ -64,13 +65,19 @@ class TableHeader extends Component {
     rows[0].push( [
       this.props.expandColumnVisible &&
         this.props.expandColumnBeforeSelectColumn &&
-          <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }/>
+          <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }
+            expandedColumnHeaderComponent={ expandedColumnHeaderComponent }
+            expandAllChilds={ expandAllChilds }
+            toggleExpandAllChilds={ toggleExpandAllChilds }/>
     ], [
       this.renderSelectRowHeader(rowCount + 1, rowKey++)
     ], [
       this.props.expandColumnVisible &&
         !this.props.expandColumnBeforeSelectColumn &&
-          <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }/>
+          <ExpandRowHeaderColumn key='expandCol' rowCount={ rowCount + 1 }
+            expandedColumnHeaderComponent={ expandedColumnHeaderComponent }
+            expandAllChilds={ expandAllChilds }
+            toggleExpandAllChilds={ toggleExpandAllChilds }/>
     ]);
 
     React.Children.forEach(this.props.children, (elm) => {
@@ -166,8 +173,11 @@ TableHeader.propTypes = {
   reset: PropTypes.bool,
   expandColumnVisible: PropTypes.bool,
   expandColumnComponent: PropTypes.func,
+  expandedColumnHeaderComponent: PropTypes.func,
   expandColumnBeforeSelectColumn: PropTypes.bool,
-  version: PropTypes.string
+  version: PropTypes.string,
+  expandAllChilds: PropTypes.bool,
+  toggleExpandAllChilds: PropTypes.func
 };
 
 export default TableHeader;


### PR DESCRIPTION
I implemented new feature to expand/collapse all rows by using header column.
It can be shown/hidden based on "**showExpandAllHeaderColumn**", "**expandAllChilds**" properties configured as part of "**options**". Even we can define custom header column using "**expandedColumnHeaderComponent**" as part of "**expandColumnOptions**"