### PR TITLE
Wrapping header content in a div element

### DIFF
--- a/src/TableHeaderColumn.js
+++ b/src/TableHeaderColumn.js
@@ -181,9 +181,11 @@ class TableHeaderColumn extends Component {
           colSpan={ this.props.colSpan }
           data-is-only-head={ this.props.isOnlyHead }
           { ...attr }>
-        { children }{ sortCaret }
-        <div onClick={ e => e.stopPropagation() }>
-          { this.props.filter && !isOnlyHead ? this.getFilters() : null }
+        <div className='header-content'>
+          { children }{ sortCaret }
+          <div onClick={ e => e.stopPropagation() }>
+            { this.props.filter && !isOnlyHead ? this.getFilters() : null }
+          </div>
         </div>
       </th>
     );


### PR DESCRIPTION
Wrapping header content in a div element in order to apply styles on all of the header elements without modifying styles of the header.

The real world case for me was to move caret (sorting indicator) before header text. The easiest way is to use display flex and flex-direction: row-reverse. Problem is that I cannot apply this styling on header directly, as it needs to have display table-cell to work properly. With this wrapper, it will be easier to style content of the header.