### PR TITLE
Add Event object to 'click' related events

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -734,10 +734,10 @@ class BootstrapTable extends Component {
     });
   }
 
-  handleRowClick = (row, rowIndex, columnIndex) => {
+  handleRowClick = (row, rowIndex, columnIndex, event) => {
     const { options, keyBoardNav } = this.props;
     if (options.onRowClick) {
-      options.onRowClick(row, columnIndex, rowIndex);
+      options.onRowClick(row, columnIndex, rowIndex, event);
     }
     if (keyBoardNav) {
       let { clickToNav } = typeof keyBoardNav === 'object' ? keyBoardNav : {};
@@ -754,9 +754,9 @@ class BootstrapTable extends Component {
     }
   }
 
-  handleRowDoubleClick = row => {
+  handleRowDoubleClick = (row, event) => {
     if (this.props.options.onRowDoubleClick) {
-      this.props.options.onRowDoubleClick(row);
+      this.props.options.onRowDoubleClick(row, event);
     }
   }
 

--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -616,10 +616,10 @@ class BootstrapTable extends Component {
     });
   }
 
-  handleExpandRow = (expanding, rowKey, isRowExpanding) => {
+  handleExpandRow = (expanding, rowKey, isRowExpanding, event) => {
     const { onExpand } = this.props.options;
     if (onExpand) {
-      onExpand(rowKey, !isRowExpanding);
+      onExpand(rowKey, !isRowExpanding, event);
     }
     this.setState(() => { return { expanding, reset: false }; }, () => {
       this._adjustHeaderWidth();

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -173,8 +173,8 @@ class TableBody extends Component {
       }
       if (isExpanding && this.props.expandParentClass) {
         trClassName += Utils.isFunction(this.props.expandParentClass) ?
-          this.props.expandParentClass(data, r) :
-          this.props.expandParentClass;
+          ` ${this.props.expandParentClass(data, r)}` :
+          ` ${this.props.expandParentClass}`;
       }
       const result = [ <TableRow isSelected={ selected } key={ key } className={ trClassName }
         index={ r }

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -308,17 +308,17 @@ class TableBody extends Component {
     this.props.onRowMouseOver(targetRow, event);
   }
 
-  handleRowClick = (rowIndex, cellIndex) => {
+  handleRowClick = (rowIndex, cellIndex, event) => {
     const { onRowClick, selectRow } = this.props;
     if (Utils.isSelectRowDefined(selectRow.mode)) cellIndex--;
     if (this._isExpandColumnVisible()) cellIndex--;
-    onRowClick(this.props.data[rowIndex - 1], rowIndex - 1, cellIndex);
+    onRowClick(this.props.data[rowIndex - 1], rowIndex - 1, cellIndex, event);
   }
 
-  handleRowDoubleClick = rowIndex => {
+  handleRowDoubleClick = (rowIndex, event) => {
     const { onRowDoubleClick } = this.props;
     const targetRow = this.props.data[rowIndex];
-    onRowDoubleClick(targetRow);
+    onRowDoubleClick(targetRow, event);
   }
 
   handleSelectRow = (rowIndex, isSelected, e) => {

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -284,7 +284,7 @@ class TableBody extends Component {
       }
 
       if (enterToExpand) {
-        this.handleClickCell(this.props.y + 1, this.props.x);
+        this.handleClickCell(e, this.props.y + 1, this.props.x);
       }
 
       if (enterToSelect) {
@@ -343,7 +343,7 @@ class TableBody extends Component {
     }
   }
 
-  handleClickCell = (rowIndex, columnIndex = -1) => {
+  handleClickCell = (event, rowIndex, columnIndex = -1) => {
     const {
       columns,
       keyField,
@@ -377,7 +377,7 @@ class TableBody extends Component {
         if (onlyOneExpanding) expanding = [ rowKey ];
         else expanding.push(rowKey);
       }
-      this.props.onExpand(expanding, rowKey, isRowExpanding);
+      this.props.onExpand(expanding, rowKey, isRowExpanding, event);
     }
   }
 
@@ -474,7 +474,7 @@ class TableBody extends Component {
       const unselectable = this.props.selectRow.unselectable || [];
       if (unselectable.indexOf(row[this.props.keyField]) === -1) {
         this.handleSelectRow(rowIndex + 1, isSelect, e);
-        this.handleClickCell(rowIndex + 1);
+        this.handleClickCell(e, rowIndex + 1);
       }
     }
   }
@@ -510,7 +510,7 @@ class TableBody extends Component {
     return (
       <td
         className='react-bs-table-expand-cell'
-        onClick={ () => this.handleClickCell(rowIndex + 1) }>
+        onClick={ e => this.handleClickCell(e, rowIndex + 1) }>
         { content }
       </td>
     );

--- a/src/TableColumn.js
+++ b/src/TableColumn.js
@@ -81,14 +81,14 @@ class TableColumn extends Component {
     this.props.onEdit(
       this.props.rIndex + 1, e.currentTarget.cellIndex, e);
     if (this.props.cellEdit.mode !== Const.CELL_EDIT_DBCLICK) {
-      this.props.onClick(this.props.rIndex + 1, e.currentTarget.cellIndex, e);
+      this.props.onClick(e, this.props.rIndex + 1, e.currentTarget.cellIndex);
     }
   }
 
   handleCellClick = e => {
     const { onClick, rIndex } = this.props;
     if (onClick) {
-      onClick(rIndex + 1, e.currentTarget.cellIndex, e);
+      onClick(e, rIndex + 1, e.currentTarget.cellIndex);
     }
   }
 

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -30,23 +30,23 @@ class TableRow extends Component {
         setTimeout(() => {
           if (this.clickNum === 1) {
             onSelectRow(rowIndex, !isSelected, e);
-            onExpandRow(rowIndex, cellIndex);
+            onExpandRow(e, rowIndex, cellIndex);
           }
           this.clickNum = 0;
         }, 200);
       } else {
         if (dbClickToEdit) {
-          this.expandRow(rowIndex, cellIndex);
+          this.expandRow(e, rowIndex, cellIndex);
         }
       }
     }
   }
 
-  expandRow = (rowIndex, cellIndex) => {
+  expandRow = (event, rowIndex, cellIndex) => {
     this.clickNum++;
     setTimeout(() => {
       if (this.clickNum === 1) {
-        this.props.onExpandRow(rowIndex, cellIndex);
+        this.props.onExpandRow(event, rowIndex, cellIndex);
       }
       this.clickNum = 0;
     }, 200);

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -14,7 +14,7 @@ class TableRow extends Component {
   rowClick = e => {
     const rowIndex = this.props.index + 1;
     const cellIndex = e.target.cellIndex;
-    if (this.props.onRowClick) this.props.onRowClick(rowIndex, cellIndex);
+    if (this.props.onRowClick) this.props.onRowClick(rowIndex, cellIndex, e);
     const {
       selectRow, unselectableRow, isSelected, onSelectRow, onExpandRow, dbClickToEdit
     } = this.props;
@@ -57,7 +57,7 @@ class TableRow extends Component {
         e.target.tagName !== 'SELECT' &&
         e.target.tagName !== 'TEXTAREA') {
       if (this.props.onRowDoubleClick) {
-        this.props.onRowDoubleClick(this.props.index);
+        this.props.onRowDoubleClick(this.props.index, e);
       }
     }
   }


### PR DESCRIPTION
- [X] Add Event as parameter to onRowClick and onRowDoubleClick
- [x] Add Event as parameter to onExpand
- [x] Fix expandParentClass option concat classNames (https://github.com/AllenFang/react-bootstrap-table/issues/1774)

Close:
- https://github.com/AllenFang/react-bootstrap-table/issues/1774
- https://github.com/AllenFang/react-bootstrap-table/issues/1766