### PR TITLE
fix issue with key when using custom page elements

### DIFF
--- a/src/pagination/PaginationList.js
+++ b/src/pagination/PaginationList.js
@@ -223,7 +223,7 @@ class PaginationList extends Component {
           false :
           true;
       }, this)
-      .map(function(page) {
+      .map(function(page, index) {
         const isActive = page === this.props.currPage;
         const isDisabled = (isStart(page, this.props) || isEnd(page, this.props)) ?
           true :
@@ -241,7 +241,7 @@ class PaginationList extends Component {
         }
 
         return (
-          <PageButton key={ page }
+          <PageButton key={ index }
             title={ title }
             changePage={ this.changePage }
             active={ isActive }
@@ -313,7 +313,10 @@ PaginationList.propTypes = {
   paginationShowsTotal: PropTypes.oneOfType([ PropTypes.bool, PropTypes.func ]),
   paginationSize: PropTypes.number,
   onSizePerPageList: PropTypes.func,
-  prePage: PropTypes.string,
+  prePage: PropTypes.any,
+  nextPage: PropTypes.any,
+  firstPage: PropTypes.any,
+  lastPage: PropTypes.any,
   pageStartIndex: PropTypes.number,
   hideSizePerPage: PropTypes.bool,
   alwaysShowAllBtns: PropTypes.bool,


### PR DESCRIPTION
For the case where `prePage`, `nextPage`, `firstPage` and `lastPage` are custom elements, the pagination breaks because we're passing them as the `key` (which turns them into `[object Object]` and we end up with duplicate keys). A simple fix is to just use the page index as the key.

Fixes #1785 

Also, fix react proptype warnings for`prePage` (it shouldn't be a `string`) and add proptypes for the other