### PR TITLE
Fixed link to scroll-table.js from the demo page

### DIFF
--- a/examples/js/basic/demo.js
+++ b/examples/js/basic/demo.js
@@ -50,7 +50,7 @@ class Demo extends React.Component {
           <LargeColumnTable/>
         </Panel>
         <Panel header={ 'Table Scroll Example' }>
-          { renderLinks('basic/scroll-table') }
+          { renderLinks('basic/scroll-table.js') }
           <span style={ { color: 'red' } }>
             You can use <code>scrollTop</code> to set the table content scroll, available value is <code>Top</code>, <code>Bottom</code> and a numeric value
           </span>


### PR DESCRIPTION
Launched the demo locally as described here https://github.com/AllenFang/react-bootstrap-table, the current link led to 404 on github