### PR TITLE
Fix: Add separator line at the beginning of created csv

### DIFF
--- a/src/csv_export_util.js
+++ b/src/csv_export_util.js
@@ -64,6 +64,7 @@ const exportCSV = function(data, keys, filename, separator, noAutoBOM, excludeCS
   const dataString = toString(data, keys, separator, excludeCSVHeader);
   if (typeof window !== 'undefined') {
     noAutoBOM = noAutoBOM === undefined ? true : noAutoBOM;
+    dataString = `sep=${separator}\n${dataString}`;
     saveAs(new Blob([ '\ufeff', dataString ],
         { type: 'text/plain;charset=utf-8' }),
         filename, noAutoBOM);


### PR DESCRIPTION
This fix allows Excel to detect the separator when opening the file and fixing the problem of all of the data shown in the same column.
With this change Excel opens csv like an xls without the need to import the csv data manually and specifying the separator.