### PR TITLE
Footer scrolling

### DIFF
--- a/src/BootstrapTable.js
+++ b/src/BootstrapTable.js
@@ -366,6 +366,8 @@ class BootstrapTable extends Component {
     this.body.container.addEventListener('scroll', this._scrollHeader);
     if (this.props.footer) {
       this.body.container.addEventListener('scroll', this._scrollFooter);
+      this.footer.container.addEventListener('scroll', this._scrollHeader);
+      this.footer.container.addEventListener('scroll', this._scrollBody);
     }
     if (this.props.scrollTop) {
       this._scrollTop();
@@ -378,6 +380,8 @@ class BootstrapTable extends Component {
       this.body.container.removeEventListener('scroll', this._scrollHeader);
       if (this.props.footer) {
         this.body.container.removeEventListener('scroll', this._scrollFooter);
+        this.footer.container.removeEventListener('scroll', this._scrollHeader);
+        this.footer.container.removeEventListener('scroll', this._scrollBody);
       }
     }
     if (this.filter) {
@@ -1446,8 +1450,13 @@ class BootstrapTable extends Component {
       this.body.container.scrollTop = scrollTop;
     }
   }
+
   _scrollHeader = (e) => {
     this.header.container.scrollLeft = e.currentTarget.scrollLeft;
+  }
+
+  _scrollBody = (e) => {
+    this.body.container.scrollLeft = e.currentTarget.scrollLeft;
   }
 
   _scrollFooter = (e) => {


### PR DESCRIPTION
Before this PR fix, in the case the Footer has a scrollbar and you move it, then the Header and Body containers scrollbars aren't moved / synced with the Footer scrollbar.

The opposite is working fine, i.e. you scroll Header, Body containers firstly and the Footer scrollbar is synced / moving correctly.

This PR syncs both Header and Body containers, when you start scrolling the Footer firstly.

Here's how it works:
![ezgif-1-f950928cd76a](https://user-images.githubusercontent.com/3863376/53096580-2b201e80-3528-11e9-81ee-37fc841345e1.gif)
